### PR TITLE
feat: implement hash joins for better performance

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,7 +20,7 @@ env:
   BENCHMARK_MEASURED_RUNS: "30"
 
 jobs:
-  benchmark-current:
+  benchmark-pr-compare:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
 
@@ -57,132 +57,51 @@ jobs:
         working-directory: apps/benchmark
         run: pnpm exec playwright install --with-deps chromium
 
-      - name: Run current benchmark suite
+      - name: Run current benchmark suite (PR head)
         working-directory: apps/benchmark
         env:
           BENCHMARK_DATASET_SIZE: ${{ env.BENCHMARK_DATASET_SIZE }}
           BENCHMARK_WARMUP_RUNS: ${{ env.BENCHMARK_WARMUP_RUNS }}
           BENCHMARK_MEASURED_RUNS: ${{ env.BENCHMARK_MEASURED_RUNS }}
-          BENCHMARK_RESULT_PATH: ${{ github.workspace }}/benchmarks/results/current.json
+          BENCHMARK_RESULT_PATH: ${{ runner.temp }}/benchmark-results/current.json
         run: |
-          mkdir -p ../../benchmarks/results
+          mkdir -p "$RUNNER_TEMP/benchmark-results"
           pnpm benchmark:ci
 
-      - name: Upload current benchmark artifact
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: benchmark-current
-          path: benchmarks/results/current.json
-          retention-days: 30
-
-  benchmark-base:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.base.sha }}
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: lts/*
-          cache: pnpm
-
-      - name: Install package dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Generate benchmark clients
-        working-directory: apps/benchmark
-        run: pnpm generate
-        env:
-          DATABASE_URL: "postgresql://placeholder@localhost:5432/placeholder"
-
-      - name: Restore Playwright browser cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
-
-      - name: Install Playwright Browser
-        working-directory: apps/benchmark
-        run: pnpm exec playwright install --with-deps chromium
-
-      - name: Run base benchmark suite
-        working-directory: apps/benchmark
-        env:
-          BENCHMARK_DATASET_SIZE: ${{ env.BENCHMARK_DATASET_SIZE }}
-          BENCHMARK_WARMUP_RUNS: ${{ env.BENCHMARK_WARMUP_RUNS }}
-          BENCHMARK_MEASURED_RUNS: ${{ env.BENCHMARK_MEASURED_RUNS }}
-          BENCHMARK_RESULT_PATH: ${{ github.workspace }}/benchmarks/results/baseline.json
+      - name: Run baseline benchmark suite (PR base)
         run: |
-          mkdir -p ../../benchmarks/results
+          git checkout --force ${{ github.event.pull_request.base.sha }}
+          pnpm install --frozen-lockfile
+          pushd apps/benchmark
+          DATABASE_URL="postgresql://placeholder@localhost:5432/placeholder" pnpm generate
+          BENCHMARK_DATASET_SIZE="${{ env.BENCHMARK_DATASET_SIZE }}" \
+          BENCHMARK_WARMUP_RUNS="${{ env.BENCHMARK_WARMUP_RUNS }}" \
+          BENCHMARK_MEASURED_RUNS="${{ env.BENCHMARK_MEASURED_RUNS }}" \
+          BENCHMARK_RESULT_PATH="$RUNNER_TEMP/benchmark-results/baseline.json" \
           pnpm benchmark:ci
+          popd
 
-      - name: Upload base benchmark artifact
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: benchmark-base
-          path: benchmarks/results/baseline.json
-          retention-days: 30
-
-  compare-benchmarks:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    needs: [benchmark-current, benchmark-base]
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: lts/*
-          cache: pnpm
-
-      - name: Install package dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Download current benchmark artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: benchmark-current
-          path: benchmarks/results
-
-      - name: Download base benchmark artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: benchmark-base
-          path: benchmarks/results
+      - name: Restore PR head checkout
+        run: |
+          git checkout --force ${{ github.sha }}
+          pnpm install --frozen-lockfile
 
       - name: Compare benchmarks
         working-directory: apps/benchmark
         run: |
-          test -f ../../benchmarks/results/baseline.json
-          test -f ../../benchmarks/results/current.json
+          test -f "$RUNNER_TEMP/benchmark-results/baseline.json"
+          test -f "$RUNNER_TEMP/benchmark-results/current.json"
           pnpm benchmark:compare \
-            --baseline ../../benchmarks/results/baseline.json \
-            --current ../../benchmarks/results/current.json \
+            --baseline "$RUNNER_TEMP/benchmark-results/baseline.json" \
+            --current "$RUNNER_TEMP/benchmark-results/current.json" \
             --threshold 10 \
-            --json-out ../../benchmarks/results/report.json \
-            --markdown-out ../../benchmarks/results/report.md
+            --json-out "$RUNNER_TEMP/benchmark-results/report.json" \
+            --markdown-out "$RUNNER_TEMP/benchmark-results/report.md"
 
       - name: Enforce benchmark regression gate
         run: |
-          jq -r '(.notices[]? | "Notice: " + .)' benchmarks/results/report.json
-          if [ "$(jq -r '.shouldFail' benchmarks/results/report.json)" = "true" ]; then
+          jq -r '(.notices[]? | "Notice: " + .)' "$RUNNER_TEMP/benchmark-results/report.json"
+          if [ "$(jq -r '.shouldFail' "$RUNNER_TEMP/benchmark-results/report.json")" = "true" ]; then
             echo "Benchmark regression gate failed." >&2
             exit 1
           fi
@@ -194,14 +113,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pnpm benchmark:comment --body-file ../../benchmarks/results/report.md
+          pnpm benchmark:comment --body-file "$RUNNER_TEMP/benchmark-results/report.md"
 
       - name: Upload benchmark artifacts
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-results
-          path: benchmarks/results/
+          path: ${{ runner.temp }}/benchmark-results/
           retention-days: 30
 
   refresh-main-baseline:
@@ -247,15 +166,15 @@ jobs:
           BENCHMARK_DATASET_SIZE: ${{ env.BENCHMARK_DATASET_SIZE }}
           BENCHMARK_WARMUP_RUNS: ${{ env.BENCHMARK_WARMUP_RUNS }}
           BENCHMARK_MEASURED_RUNS: ${{ env.BENCHMARK_MEASURED_RUNS }}
-          BENCHMARK_RESULT_PATH: ${{ github.workspace }}/benchmarks/results/current.json
+          BENCHMARK_RESULT_PATH: ${{ runner.temp }}/benchmark-results/main-current.json
         run: |
-          mkdir -p ../../benchmarks/results
+          mkdir -p "$RUNNER_TEMP/benchmark-results"
           pnpm benchmark:ci
 
       - name: Refresh main baseline snapshot
         run: |
           mkdir -p benchmarks/baselines
-          cp benchmarks/results/current.json benchmarks/baselines/main.json
+          cp "$RUNNER_TEMP/benchmark-results/main-current.json" benchmarks/baselines/main.json
 
       - name: Commit baseline update
         run: |
@@ -281,5 +200,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-results-main
-          path: benchmarks/results/
+          path: ${{ runner.temp }}/benchmark-results/
           retention-days: 30

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,8 +14,14 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  BENCHMARK_DATASET_SIZE: "1000"
+  BENCHMARK_WARMUP_RUNS: "2"
+  BENCHMARK_MEASURED_RUNS: "30"
+
 jobs:
-  benchmark:
+  benchmark-current:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
 
     steps:
@@ -23,74 +29,149 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: ./.github/actions/
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: pnpm
+
+      - name: Install package dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate benchmark clients
+        working-directory: apps/benchmark
+        run: pnpm generate
+        env:
+          DATABASE_URL: "postgresql://placeholder@localhost:5432/placeholder"
+
+      - name: Restore Playwright browser cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install Playwright Browser
         working-directory: apps/benchmark
         run: pnpm exec playwright install --with-deps chromium
 
-      - name: Run benchmark suite
+      - name: Run current benchmark suite
         working-directory: apps/benchmark
+        env:
+          BENCHMARK_DATASET_SIZE: ${{ env.BENCHMARK_DATASET_SIZE }}
+          BENCHMARK_WARMUP_RUNS: ${{ env.BENCHMARK_WARMUP_RUNS }}
+          BENCHMARK_MEASURED_RUNS: ${{ env.BENCHMARK_MEASURED_RUNS }}
+          BENCHMARK_RESULT_PATH: ${{ github.workspace }}/benchmarks/results/current.json
         run: |
           mkdir -p ../../benchmarks/results
           pnpm benchmark:ci
 
-      - name: Capture current benchmark config
-        if: github.event_name == 'pull_request'
-        run: |
-          jq -er '
-            .config
-            | if (.datasetSize | type) != "number" or (.warmupRuns | type) != "number" or (.measuredRuns | type) != "number"
-              then error("Missing integer config in benchmarks/results/current.json")
-              else "BENCHMARK_DATASET_SIZE=\(.datasetSize)\nBENCHMARK_WARMUP_RUNS=\(.warmupRuns)\nBENCHMARK_MEASURED_RUNS=\(.measuredRuns)"
-              end
-          ' benchmarks/results/current.json >> "$GITHUB_ENV"
+      - name: Upload current benchmark artifact
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-current
+          path: benchmarks/results/current.json
+          retention-days: 30
 
-      - name: Check out PR base commit
-        if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
+  benchmark-base:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          path: benchmark-base
           ref: ${{ github.event.pull_request.base.sha }}
 
-      - name: Install base commit dependencies
-        if: github.event_name == 'pull_request'
-        working-directory: benchmark-base
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: pnpm
+
+      - name: Install package dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Sync base commit SvelteKit
-        if: github.event_name == 'pull_request'
-        working-directory: benchmark-base
-        run: pnpm --filter usage exec svelte-kit sync
-
-      - name: Generate base commit clients
-        if: github.event_name == 'pull_request'
-        working-directory: benchmark-base
+      - name: Generate benchmark clients
+        working-directory: apps/benchmark
         run: pnpm generate
         env:
           DATABASE_URL: "postgresql://placeholder@localhost:5432/placeholder"
 
-      - name: Install base commit Playwright browser
-        if: github.event_name == 'pull_request'
-        working-directory: benchmark-base/apps/benchmark
+      - name: Restore Playwright browser cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install Playwright Browser
+        working-directory: apps/benchmark
         run: pnpm exec playwright install --with-deps chromium
 
-      - name: Benchmark PR base commit
-        if: github.event_name == 'pull_request'
-        working-directory: benchmark-base/apps/benchmark
+      - name: Run base benchmark suite
+        working-directory: apps/benchmark
         env:
           BENCHMARK_DATASET_SIZE: ${{ env.BENCHMARK_DATASET_SIZE }}
           BENCHMARK_WARMUP_RUNS: ${{ env.BENCHMARK_WARMUP_RUNS }}
           BENCHMARK_MEASURED_RUNS: ${{ env.BENCHMARK_MEASURED_RUNS }}
           BENCHMARK_RESULT_PATH: ${{ github.workspace }}/benchmarks/results/baseline.json
-        run: pnpm benchmark:ci
+        run: |
+          mkdir -p ../../benchmarks/results
+          pnpm benchmark:ci
+
+      - name: Upload base benchmark artifact
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-base
+          path: benchmarks/results/baseline.json
+          retention-days: 30
+
+  compare-benchmarks:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    needs: [benchmark-current, benchmark-base]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: pnpm
+
+      - name: Install package dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download current benchmark artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmark-current
+          path: benchmarks/results
+
+      - name: Download base benchmark artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmark-base
+          path: benchmarks/results
 
       - name: Compare benchmarks
-        if: github.event_name == 'pull_request'
         working-directory: apps/benchmark
         run: |
           test -f ../../benchmarks/results/baseline.json
+          test -f ../../benchmarks/results/current.json
           pnpm benchmark:compare \
             --baseline ../../benchmarks/results/baseline.json \
             --current ../../benchmarks/results/current.json \
@@ -99,7 +180,6 @@ jobs:
             --markdown-out ../../benchmarks/results/report.md
 
       - name: Enforce benchmark regression gate
-        if: github.event_name == 'pull_request'
         run: |
           jq -r '(.notices[]? | "Notice: " + .)' benchmarks/results/report.json
           if [ "$(jq -r '.shouldFail' benchmarks/results/report.json)" = "true" ]; then
@@ -108,7 +188,7 @@ jobs:
           fi
 
       - name: Publish benchmark PR comment
-        if: github.event_name == 'pull_request' && !cancelled() && github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
         continue-on-error: true
         working-directory: apps/benchmark
         env:
@@ -116,14 +196,68 @@ jobs:
         run: |
           pnpm benchmark:comment --body-file ../../benchmarks/results/report.md
 
+      - name: Upload benchmark artifacts
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: benchmarks/results/
+          retention-days: 30
+
+  refresh-main-baseline:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: pnpm
+
+      - name: Install package dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate benchmark clients
+        working-directory: apps/benchmark
+        run: pnpm generate
+        env:
+          DATABASE_URL: "postgresql://placeholder@localhost:5432/placeholder"
+
+      - name: Restore Playwright browser cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install Playwright Browser
+        working-directory: apps/benchmark
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run benchmark suite
+        working-directory: apps/benchmark
+        env:
+          BENCHMARK_DATASET_SIZE: ${{ env.BENCHMARK_DATASET_SIZE }}
+          BENCHMARK_WARMUP_RUNS: ${{ env.BENCHMARK_WARMUP_RUNS }}
+          BENCHMARK_MEASURED_RUNS: ${{ env.BENCHMARK_MEASURED_RUNS }}
+          BENCHMARK_RESULT_PATH: ${{ github.workspace }}/benchmarks/results/current.json
+        run: |
+          mkdir -p ../../benchmarks/results
+          pnpm benchmark:ci
+
       - name: Refresh main baseline snapshot
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           mkdir -p benchmarks/baselines
           cp benchmarks/results/current.json benchmarks/baselines/main.json
 
       - name: Commit baseline update
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           # Check for both tracked changes and newly created/untracked baselines
           if [ ! -f benchmarks/baselines/main.json ] || git diff --quiet -- benchmarks/baselines/main.json; then
@@ -146,6 +280,6 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: benchmark-results
+          name: benchmark-results-main
           path: benchmarks/results/
           retention-days: 30

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -46,39 +46,8 @@ jobs:
               end
           ' benchmarks/results/current.json >> "$GITHUB_ENV"
 
-      - name: Load trusted baseline from PR base commit
+      - name: Check out PR base commit
         if: github.event_name == 'pull_request'
-        run: |
-          BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          TARGET_PATH="benchmarks/results/baseline-main.json"
-          TEMP_PATH="$(mktemp)"
-
-          if git show "$BASE_SHA:benchmarks/baselines/main.json" > "$TEMP_PATH"; then
-            mv "$TEMP_PATH" "$TARGET_PATH"
-            echo "Loaded baseline snapshot from base commit: $BASE_SHA"
-          else
-            rm -f "$TEMP_PATH"
-            echo "Baseline snapshot not found at base commit: $BASE_SHA"
-            exit 1
-          fi
-
-      - name: Compare against trusted baseline
-        if: github.event_name == 'pull_request'
-        id: compare_trusted_baseline
-        working-directory: apps/benchmark
-        run: |
-          test -f ../../benchmarks/results/baseline-main.json
-          pnpm benchmark:compare \
-            --baseline ../../benchmarks/results/baseline-main.json \
-            --current ../../benchmarks/results/current.json \
-            --threshold 10 \
-            --json-out ../../benchmarks/results/report.json \
-            --markdown-out ../../benchmarks/results/report.md
-
-          jq -r '"is_advisory=\(.isAdvisory)"' ../../benchmarks/results/report.json >> "$GITHUB_OUTPUT"
-
-      - name: Check out PR base commit for direct benchmark
-        if: github.event_name == 'pull_request' && steps.compare_trusted_baseline.outputs.is_advisory == 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -86,44 +55,44 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Install base commit dependencies
-        if: github.event_name == 'pull_request' && steps.compare_trusted_baseline.outputs.is_advisory == 'true'
+        if: github.event_name == 'pull_request'
         working-directory: benchmark-base
         run: pnpm install --frozen-lockfile
 
       - name: Sync base commit SvelteKit
-        if: github.event_name == 'pull_request' && steps.compare_trusted_baseline.outputs.is_advisory == 'true'
+        if: github.event_name == 'pull_request'
         working-directory: benchmark-base
         run: pnpm --filter usage exec svelte-kit sync
 
       - name: Generate base commit clients
-        if: github.event_name == 'pull_request' && steps.compare_trusted_baseline.outputs.is_advisory == 'true'
+        if: github.event_name == 'pull_request'
         working-directory: benchmark-base
         run: pnpm generate
         env:
           DATABASE_URL: "postgresql://placeholder@localhost:5432/placeholder"
 
       - name: Install base commit Playwright browser
-        if: github.event_name == 'pull_request' && steps.compare_trusted_baseline.outputs.is_advisory == 'true'
+        if: github.event_name == 'pull_request'
         working-directory: benchmark-base/apps/benchmark
         run: pnpm exec playwright install --with-deps chromium
 
-      - name: Benchmark PR base commit directly
-        if: github.event_name == 'pull_request' && steps.compare_trusted_baseline.outputs.is_advisory == 'true'
+      - name: Benchmark PR base commit
+        if: github.event_name == 'pull_request'
         working-directory: benchmark-base/apps/benchmark
         env:
           BENCHMARK_DATASET_SIZE: ${{ env.BENCHMARK_DATASET_SIZE }}
           BENCHMARK_WARMUP_RUNS: ${{ env.BENCHMARK_WARMUP_RUNS }}
           BENCHMARK_MEASURED_RUNS: ${{ env.BENCHMARK_MEASURED_RUNS }}
-          BENCHMARK_RESULT_PATH: ${{ github.workspace }}/benchmarks/results/base-current.json
+          BENCHMARK_RESULT_PATH: ${{ github.workspace }}/benchmarks/results/baseline.json
         run: pnpm benchmark:ci
 
-      - name: Compare against directly benchmarked base commit
-        if: github.event_name == 'pull_request' && steps.compare_trusted_baseline.outputs.is_advisory == 'true'
+      - name: Compare benchmarks
+        if: github.event_name == 'pull_request'
         working-directory: apps/benchmark
         run: |
-          test -f ../../benchmarks/results/base-current.json
+          test -f ../../benchmarks/results/baseline.json
           pnpm benchmark:compare \
-            --baseline ../../benchmarks/results/base-current.json \
+            --baseline ../../benchmarks/results/baseline.json \
             --current ../../benchmarks/results/current.json \
             --threshold 10 \
             --json-out ../../benchmarks/results/report.json \
@@ -132,7 +101,7 @@ jobs:
       - name: Enforce benchmark regression gate
         if: github.event_name == 'pull_request'
         run: |
-          jq -r '"Final benchmark gate mode: " + (if .isAdvisory then "advisory" else "enforcing" end), (.notices[]? | "Notice: " + .)' benchmarks/results/report.json
+          jq -r '(.notices[]? | "Notice: " + .)' benchmarks/results/report.json
           if [ "$(jq -r '.shouldFail' benchmarks/results/report.json)" = "true" ]; then
             echo "Benchmark regression gate failed." >&2
             exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,7 @@ out
 **/playwright-report/**
 /playwright/.cache/
 /benchmarks/results/
+/benchmarks/act-artifacts/
+/benchmarks/act-cache/
 
 todo.md

--- a/apps/benchmark/README.md
+++ b/apps/benchmark/README.md
@@ -29,11 +29,10 @@ Local-first benchmark dashboard for Prisma IDB generated clients.
 ## CI Regression Gate
 
 - CI runs benchmarks in headless Chromium via Playwright using `/?autoStart` with config query params.
-- The default benchmark preset uses 20 measured runs so p95 is estimated from a meaningful sample size.
+- PR benchmark comparisons run the PR head and PR base commit back-to-back on the same GitHub runner to reduce VM-to-VM variance.
 - Baseline snapshot is stored in `benchmarks/baselines/main.json` and refreshed on successful pushes to `main`.
-- PR checks do **not** trust the baseline file from the PR branch; they load the baseline from the PR base commit on `main`.
-- PR runs compare current results against baseline and fail if any operation p95 latency regresses by more than 10%.
-- If the trusted snapshot comparison is still advisory, CI benchmarks the PR base commit directly using the same config and uses that run for the final gate.
-- If baseline and current runs use insufficient or mismatched sample counts, the comparison is reported as advisory instead of enforcing.
+- PR checks do **not** trust the baseline file from the PR branch; they benchmark the PR base commit directly using the same config.
+- PR runs compare current results against baseline and fail only when the bootstrap 95% CI lower bound of median latency delta exceeds the threshold.
+- If baseline and current runs have insufficient or mismatched sample data, the comparison is reported as advisory instead of enforcing.
 - Newly added benchmark operations are reported in PR comments but do not fail the gate; removing baseline operations fails the gate.
 - CI posts a sticky PR comment with a per-operation delta table.

--- a/apps/benchmark/next.config.mjs
+++ b/apps/benchmark/next.config.mjs
@@ -1,8 +1,20 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = path.resolve(dirname, "../..");
+
 /** @type {import('next').NextConfig} */
 const config = {
   output: "export",
   reactStrictMode: true,
   images: { unoptimized: true },
+  turbopack: {
+    // With pnpm, Next can resolve from the workspace-level virtual store.
+    // Pin root to monorepo root so Turbopack can resolve package paths safely.
+    root: workspaceRoot,
+  },
+  outputFileTracingRoot: workspaceRoot,
   experimental: {
     optimizePackageImports: ["lucide-react", "recharts"],
     externalDir: true,

--- a/apps/benchmark/package.json
+++ b/apps/benchmark/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.4.0",
+    "@vercel/analytics": "^2.0.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "geist": "^1.7.0",

--- a/apps/benchmark/scripts/compare-benchmark-results.ts
+++ b/apps/benchmark/scripts/compare-benchmark-results.ts
@@ -12,6 +12,7 @@ interface BenchmarkOperation {
 interface BenchmarkRun {
   id?: string;
   browser?: string;
+  platform?: string;
   operations?: BenchmarkOperation[];
 }
 
@@ -174,31 +175,15 @@ function getComparisonNotices(baseline: BenchmarkRun, current: BenchmarkRun): st
     );
   }
 
-  const baselinePlatform = getPlatformToken(baseline.browser);
-  const currentPlatform = getPlatformToken(current.browser);
-  if (baselinePlatform && currentPlatform && baselinePlatform !== currentPlatform) {
+  if (baseline.platform !== current.platform) {
+    const bl = baseline.platform ?? "unknown";
+    const cl = current.platform ?? "unknown";
     notices.push(
-      `Baseline and current runs were captured on different platforms (\`${baselinePlatform}\` vs \`${currentPlatform}\`); absolute timings are not comparable, so this comparison is advisory.`
+      `Baseline and current runs were captured on different platforms (\`${bl}\` vs \`${cl}\`); absolute timings are not comparable, so this comparison is advisory.`
     );
   }
 
   return notices;
-}
-
-/**
- * Extracts a coarse platform token ("Macintosh", "Linux", "Windows", "Android", "iOS")
- * from a browser User-Agent string. Returns null if the UA is missing or unrecognised.
- * Used to detect when baseline and current runs come from different machines (e.g. a
- * fast laptop baseline vs a slower CI runner) — a scenario where regression % is meaningless.
- */
-function getPlatformToken(userAgent: string | undefined): string | null {
-  if (!userAgent) return null;
-  if (/Macintosh|Mac OS X/i.test(userAgent)) return "Macintosh";
-  if (/Windows/i.test(userAgent)) return "Windows";
-  if (/Android/i.test(userAgent)) return "Android";
-  if (/iPhone|iPad|iOS/i.test(userAgent)) return "iOS";
-  if (/Linux|X11/i.test(userAgent)) return "Linux";
-  return null;
 }
 
 async function writeOutput(filePath: string | undefined, content: string): Promise<void> {

--- a/apps/benchmark/scripts/compare-benchmark-results.ts
+++ b/apps/benchmark/scripts/compare-benchmark-results.ts
@@ -112,9 +112,9 @@ function renderMarkdown(summary: ComparisonSummary, threshold: number): string {
     "",
     `| Summary | |`,
     `| :-- | :-- |`,
-    `| **Gate metric** | p95 latency |`,
+    `| **Gate metric** | p95 latency (corroborated by mean) |`,
     `| **Gate mode** | ${gateIcon} ${gateLabel} |`,
-    `| **Regression threshold** | +${threshold}% and ≥${BENCHMARK_REGRESSION_GATE.minAbsoluteDeltaMs}ms absolute |`,
+    `| **Regression threshold** | p95 > +${threshold}% and ≥${BENCHMARK_REGRESSION_GATE.minAbsoluteDeltaMs}ms absolute, mean > +${BENCHMARK_REGRESSION_GATE.meanCorroborationPercent}% |`,
     `| **Compared operations** | ${summary.rows.length} |`,
     `| **Regressions** | ${summary.regressions.length > 0 ? `⚠️ ${summary.regressions.length}` : `${summary.regressions.length}`} |`,
     `| **Added / Removed** | ${summary.addedOperations.length} / ${summary.removedOperations.length} |`,
@@ -300,7 +300,11 @@ async function main() {
       p95.baseline !== null && p95.current !== null ? Math.abs(p95.current - p95.baseline) : null;
     const exceedsPercent = delta !== null && (!Number.isFinite(delta) || delta > threshold);
     const exceedsAbsolute = absoluteP95Delta === null || absoluteP95Delta >= minAbsDelta;
-    const isRegression = exceedsPercent && exceedsAbsolute;
+    const meanDelta = mean.delta;
+    const meanCorroborates =
+      meanDelta !== null &&
+      (!Number.isFinite(meanDelta) || meanDelta > BENCHMARK_REGRESSION_GATE.meanCorroborationPercent);
+    const isRegression = exceedsPercent && exceedsAbsolute && meanCorroborates;
     const isWarn = !isRegression && (delta === null || delta >= threshold / 2);
 
     const row: ComparisonRow = {

--- a/apps/benchmark/scripts/compare-benchmark-results.ts
+++ b/apps/benchmark/scripts/compare-benchmark-results.ts
@@ -115,16 +115,30 @@ function bootstrapMedianDeltaCI(
   const baselineDraw = new Array<number>(baselineN);
   const currentDraw = new Array<number>(currentN);
 
+  // Deterministic LCG seeded from a constant so identical inputs produce
+  // identical CIs across runs (avoids gate flapping on borderline regressions).
+  let rngState = 0x9e3779b9;
+  const nextRandom = () => {
+    rngState = (Math.imul(1664525, rngState) + 1013904223) >>> 0;
+    return rngState / 0x100000000;
+  };
+
   for (let i = 0; i < iterations; i++) {
     for (let j = 0; j < baselineN; j++) {
-      baselineDraw[j] = baselineSamples[Math.floor(Math.random() * baselineN)];
+      baselineDraw[j] = baselineSamples[Math.floor(nextRandom() * baselineN)];
     }
     for (let j = 0; j < currentN; j++) {
-      currentDraw[j] = currentSamples[Math.floor(Math.random() * currentN)];
+      currentDraw[j] = currentSamples[Math.floor(nextRandom() * currentN)];
     }
     const bMed = medianOf(baselineDraw);
     const cMed = medianOf(currentDraw);
-    replicateDeltas[i] = bMed === 0 ? Number.POSITIVE_INFINITY : ((cMed - bMed) / bMed) * 100;
+    if (bMed === 0 && cMed === 0) {
+      replicateDeltas[i] = 0;
+    } else if (bMed === 0) {
+      replicateDeltas[i] = cMed > 0 ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY;
+    } else {
+      replicateDeltas[i] = ((cMed - bMed) / bMed) * 100;
+    }
   }
 
   replicateDeltas.sort((a, b) => a - b);

--- a/apps/benchmark/scripts/compare-benchmark-results.ts
+++ b/apps/benchmark/scripts/compare-benchmark-results.ts
@@ -168,21 +168,45 @@ function formatMetric(value: number | null): string {
   return value === null ? "n/a" : String(value);
 }
 
-function formatDelta(value: number | null, threshold: number): string {
-  if (value === null) return "n/a";
-  if (!Number.isFinite(value)) return value > 0 ? "+∞" : "-∞";
-  const sign = value > 0 ? "+" : "";
-  const formatted = `${sign}${value.toFixed(2)}%`;
-  if (value > threshold) return `**${formatted}** 📈`;
-  if (value < -threshold) return `**${formatted}** 📉`;
-  return formatted;
-}
-
 function formatDeltaCompact(value: number | null): string {
   if (value === null) return "n/a";
   if (!Number.isFinite(value)) return value > 0 ? "+∞" : "-∞";
   const sign = value > 0 ? "+" : "";
   return `${sign}${value.toFixed(2)}%`;
+}
+
+function exceedsThresholdInDirection(
+  value: number | null,
+  threshold: number,
+  direction: "positive" | "negative"
+): boolean {
+  if (value === null) return false;
+  if (!Number.isFinite(value))
+    return direction === "positive" ? value === Number.POSITIVE_INFINITY : value === Number.NEGATIVE_INFINITY;
+  return direction === "positive" ? value > threshold : value < -threshold;
+}
+
+function getAbsoluteMedianDeltaMs(row: ComparisonRow): number | null {
+  return row.median.baseline !== null && row.median.current !== null
+    ? Math.abs(row.median.current - row.median.baseline)
+    : null;
+}
+
+function isClearSpeedup(row: ComparisonRow, threshold: number): boolean {
+  if (!row.bootstrap) return false;
+  const absoluteMedianDelta = getAbsoluteMedianDeltaMs(row);
+  const exceedsAbsolute =
+    absoluteMedianDelta === null || absoluteMedianDelta >= BENCHMARK_REGRESSION_GATE.minAbsoluteDeltaMs;
+  return exceedsAbsolute && exceedsThresholdInDirection(row.bootstrap.ciUpperPercent, threshold, "negative");
+}
+
+function describeTrend(row: ComparisonRow, threshold: number): string {
+  if (!row.bootstrap) return "No sample data";
+  if (row.status === "FAIL") return row.noisy ? "Noisy slowdown" : "Slowdown";
+  if (row.status === "WARN") return "Possible slowdown";
+  if (isClearSpeedup(row, threshold)) return "Speedup";
+  if (exceedsThresholdInDirection(row.bootstrap.medianDeltaPercent, threshold, "negative")) return "Leaning faster";
+  return "No clear change";
 }
 
 function formatCIBound(value: number): string {
@@ -218,6 +242,13 @@ function pairMetric(baseline: number, current: number): MetricPair {
 function renderMarkdown(summary: ComparisonSummary, threshold: number): string {
   const noisyRegressions = summary.rows.filter((r) => r.status === "FAIL" && r.noisy).length;
   const potentialRegressions = summary.rows.filter((r) => r.status === "WARN").length;
+  const clearSpeedups = summary.rows.filter((r) => isClearSpeedup(r, threshold)).length;
+  const leaningFaster = summary.rows.filter(
+    (r) =>
+      !isClearSpeedup(r, threshold) &&
+      r.bootstrap &&
+      exceedsThresholdInDirection(r.bootstrap.medianDeltaPercent, threshold, "negative")
+  ).length;
 
   const gateLabel = summary.isAdvisory
     ? "ℹ️ advisory only (non-blocking)"
@@ -237,6 +268,8 @@ function renderMarkdown(summary: ComparisonSummary, threshold: number): string {
     `| **Blocking regressions** | ${summary.regressions.length} |`,
     `| **Potential regressions** | ${potentialRegressions} |`,
     `| **Noisy regressions (non-blocking)** | ${noisyRegressions} |`,
+    `| **Clear speedups** | ${clearSpeedups} |`,
+    `| **Leaning faster** | ${leaningFaster} |`,
     `| **Added / Removed** | ${summary.addedOperations.length} / ${summary.removedOperations.length} |`,
     "",
   ];
@@ -255,8 +288,8 @@ function renderMarkdown(summary: ComparisonSummary, threshold: number): string {
   lines.push("");
 
   lines.push(
-    "| Status | Operation | Gate decision | Median Δ (95% CI) | Baseline median | Current median |",
-    "| :---: | :-- | :-- | :--- | ---: | ---: |"
+    "| Status | Operation | Trend | Gate decision | Median Δ | 95% CI | Baseline median | Current median |",
+    "| :---: | :-- | :-- | :-- | ---: | :-- | ---: | ---: |"
   );
 
   for (const row of summary.rows) {
@@ -277,11 +310,13 @@ function renderMarkdown(summary: ComparisonSummary, threshold: number): string {
         : row.status === "WARN"
           ? `Point estimate > +${threshold}% but CI lower <= +${threshold}%`
           : `CI lower <= +${threshold}%`;
-    const ciCell = row.bootstrap
-      ? `${formatDelta(row.bootstrap.medianDeltaPercent, threshold)} (${formatCIBound(row.bootstrap.ciLowerPercent)} … ${formatCIBound(row.bootstrap.ciUpperPercent)})`
+    const medianDelta = row.bootstrap ? formatDeltaCompact(row.bootstrap.medianDeltaPercent) : "n/a";
+    const ciRange = row.bootstrap
+      ? `${formatCIBound(row.bootstrap.ciLowerPercent)} … ${formatCIBound(row.bootstrap.ciUpperPercent)}`
       : "n/a";
+    const trend = describeTrend(row, threshold);
     lines.push(
-      `| ${statusIcon} | \`${row.operationId}\`${noisyTag} | ${decision} | ${ciCell} | ${formatMetric(row.median.baseline)} | ${formatMetric(row.median.current)} |`
+      `| ${statusIcon} | \`${row.operationId}\`${noisyTag} | ${trend} | ${decision} | ${medianDelta} | ${ciRange} | ${formatMetric(row.median.baseline)} | ${formatMetric(row.median.current)} |`
     );
   }
 

--- a/apps/benchmark/scripts/compare-benchmark-results.ts
+++ b/apps/benchmark/scripts/compare-benchmark-results.ts
@@ -23,10 +23,24 @@ interface MetricPair {
   delta: number | null;
 }
 
+interface BootstrapCI {
+  /** Percent change in median, point estimate from observed samples. */
+  medianDeltaPercent: number;
+  /** 95% CI lower bound on the percent change in median. */
+  ciLowerPercent: number;
+  /** 95% CI upper bound on the percent change in median. */
+  ciUpperPercent: number;
+  /** Number of bootstrap resamples used. */
+  iterations: number;
+}
+
 interface ComparisonRow {
   operationId: string;
   p95: MetricPair;
   mean: MetricPair;
+  median: MetricPair;
+  /** Bootstrap CI on the percent change in median. `null` when sample data is missing. */
+  bootstrap: BootstrapCI | null;
   status: "PASS" | "WARN" | "FAIL";
   noisy?: boolean;
 }
@@ -50,6 +64,9 @@ const round = (value: number) => Number(value.toFixed(3));
 /** Coefficient of variation threshold above which a measurement is flagged as noisy. */
 const CV_THRESHOLD = 0.3;
 
+/** Number of bootstrap resamples used to compute the CI on the median delta. */
+const BOOTSTRAP_ITERATIONS = 2000;
+
 /** Coefficient of variation (stdDev / mean). High CV → noisy measurement. */
 function coefficientOfVariation(samples: number[] | undefined): number | null {
   if (!samples || samples.length < 2) return null;
@@ -60,18 +77,86 @@ function coefficientOfVariation(samples: number[] | undefined): number | null {
   return Math.sqrt(variance) / mean;
 }
 
+function medianOf(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const n = sorted.length;
+  if (n === 0) return Number.NaN;
+  const mid = Math.floor(n / 2);
+  return n % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+/**
+ * Bootstrap confidence interval on the percent change in median between two
+ * sample sets. Resamples both arrays with replacement, computes the median
+ * delta on each replicate, and returns the 2.5th / 97.5th percentiles as the
+ * 95% CI bounds.
+ *
+ * Using the CI lower bound (instead of a point estimate) as the gate criterion
+ * naturally handles benchmark noise: a true regression is one where even the
+ * pessimistic edge of the CI exceeds the threshold.
+ */
+function bootstrapMedianDeltaCI(
+  baselineSamples: number[] | undefined,
+  currentSamples: number[] | undefined,
+  iterations: number = BOOTSTRAP_ITERATIONS
+): BootstrapCI | null {
+  if (!baselineSamples || !currentSamples) return null;
+  if (baselineSamples.length < 2 || currentSamples.length < 2) return null;
+
+  const baselineMedian = medianOf(baselineSamples);
+  const currentMedian = medianOf(currentSamples);
+  if (!Number.isFinite(baselineMedian) || baselineMedian === 0) return null;
+
+  const observedDelta = ((currentMedian - baselineMedian) / baselineMedian) * 100;
+
+  const replicateDeltas: number[] = new Array(iterations);
+  const baselineN = baselineSamples.length;
+  const currentN = currentSamples.length;
+  const baselineDraw = new Array<number>(baselineN);
+  const currentDraw = new Array<number>(currentN);
+
+  for (let i = 0; i < iterations; i++) {
+    for (let j = 0; j < baselineN; j++) {
+      baselineDraw[j] = baselineSamples[Math.floor(Math.random() * baselineN)];
+    }
+    for (let j = 0; j < currentN; j++) {
+      currentDraw[j] = currentSamples[Math.floor(Math.random() * currentN)];
+    }
+    const bMed = medianOf(baselineDraw);
+    const cMed = medianOf(currentDraw);
+    replicateDeltas[i] = bMed === 0 ? Number.POSITIVE_INFINITY : ((cMed - bMed) / bMed) * 100;
+  }
+
+  replicateDeltas.sort((a, b) => a - b);
+  const lowerIdx = Math.floor(0.025 * iterations);
+  const upperIdx = Math.min(iterations - 1, Math.floor(0.975 * iterations));
+
+  return {
+    medianDeltaPercent: round(observedDelta),
+    ciLowerPercent: round(replicateDeltas[lowerIdx]),
+    ciUpperPercent: round(replicateDeltas[upperIdx]),
+    iterations,
+  };
+}
+
 function formatMetric(value: number | null): string {
   return value === null ? "n/a" : String(value);
 }
 
 function formatDelta(value: number | null): string {
   if (value === null) return "n/a";
-  if (!Number.isFinite(value)) return "∞";
+  if (!Number.isFinite(value)) return value > 0 ? "+∞" : "-∞";
   const sign = value > 0 ? "+" : "";
   const formatted = `${sign}${value.toFixed(2)}%`;
   if (value > 10) return `**${formatted}** 📈`;
   if (value < -10) return `**${formatted}** 📉`;
   return formatted;
+}
+
+function formatCIBound(value: number): string {
+  if (!Number.isFinite(value)) return value > 0 ? "+∞" : "-∞";
+  const sign = value > 0 ? "+" : "";
+  return `${sign}${value.toFixed(1)}%`;
 }
 
 function pairMetric(baseline: number, current: number): MetricPair {
@@ -112,9 +197,9 @@ function renderMarkdown(summary: ComparisonSummary, threshold: number): string {
     "",
     `| Summary | |`,
     `| :-- | :-- |`,
-    `| **Gate metric** | p95 latency (corroborated by mean) |`,
+    `| **Gate metric** | bootstrap 95% CI on median delta |`,
     `| **Gate mode** | ${gateIcon} ${gateLabel} |`,
-    `| **Regression threshold** | p95 > +${threshold}% and ≥${BENCHMARK_REGRESSION_GATE.minAbsoluteDeltaMs}ms absolute, mean > +${BENCHMARK_REGRESSION_GATE.meanCorroborationPercent}% |`,
+    `| **Regression threshold** | CI lower bound > +${threshold}% and ≥${BENCHMARK_REGRESSION_GATE.minAbsoluteDeltaMs}ms absolute median change |`,
     `| **Compared operations** | ${summary.rows.length} |`,
     `| **Regressions** | ${summary.regressions.length > 0 ? `⚠️ ${summary.regressions.length}` : `${summary.regressions.length}`} |`,
     `| **Added / Removed** | ${summary.addedOperations.length} / ${summary.removedOperations.length} |`,
@@ -128,17 +213,27 @@ function renderMarkdown(summary: ComparisonSummary, threshold: number): string {
   }
 
   lines.push(
-    "| Status | Operation | Baseline p95 | Current p95 | Δ p95 | Baseline mean | Current mean | Δ mean |",
-    "| :---: | :-- | ---: | ---: | ---: | ---: | ---: | ---: |"
+    "| Status | Operation | Median Δ (95% CI) | Baseline median | Current median | Δ p95 | Δ mean |",
+    "| :---: | :-- | :--- | ---: | ---: | ---: | ---: |"
   );
 
   for (const row of summary.rows) {
-    const statusIcon = row.status === "FAIL" ? (row.noisy ? "🟠" : "🔴") : row.status === "WARN" ? "🟡" : "🟢";
-    const noisyTag = row.noisy ? " 🎲" : "";
+    const statusIcon =
+      row.status === "FAIL"
+        ? row.noisy
+          ? "\uD83D\uDFE0"
+          : "\uD83D\uDD34"
+        : row.status === "WARN"
+          ? "\uD83D\uDFE1"
+          : "\uD83D\uDFE2";
+    const noisyTag = row.noisy ? " \uD83C\uDFB2" : "";
+    const ciCell = row.bootstrap
+      ? `${formatDelta(row.bootstrap.medianDeltaPercent)} (${formatCIBound(row.bootstrap.ciLowerPercent)} … ${formatCIBound(row.bootstrap.ciUpperPercent)})`
+      : "n/a";
     const deltaP95 = formatDelta(row.p95.delta);
     const deltaMean = formatDelta(row.mean.delta);
     lines.push(
-      `| ${statusIcon} | \`${row.operationId}\`${noisyTag} | ${formatMetric(row.p95.baseline)} | ${formatMetric(row.p95.current)} | ${deltaP95} | ${formatMetric(row.mean.baseline)} | ${formatMetric(row.mean.current)} | ${deltaMean} |`
+      `| ${statusIcon} | \`${row.operationId}\`${noisyTag} | ${ciCell} | ${formatMetric(row.median.baseline)} | ${formatMetric(row.median.current)} | ${deltaP95} | ${deltaMean} |`
     );
   }
 
@@ -159,9 +254,9 @@ function renderMarkdown(summary: ComparisonSummary, threshold: number): string {
   lines.push("<details><summary>Legend</summary>", "");
   lines.push("| Symbol | Meaning |");
   lines.push("| :---: | :-- |");
-  lines.push("| 🟢 | Pass — within threshold |");
-  lines.push("| 🟡 | Warn — approaching threshold |");
-  lines.push("| 🔴 | Fail — exceeds threshold |");
+  lines.push("| 🟢 | Pass — CI lower bound is within threshold |");
+  lines.push("| 🟡 | Warn — point estimate exceeds threshold but CI lower bound does not (likely noise) |");
+  lines.push("| 🔴 | Fail — even pessimistic edge of CI exceeds threshold |");
   if (hasNoisyFail) {
     lines.push("| 🟠 | Fail but noisy — high variance makes this unreliable |");
   }
@@ -284,33 +379,46 @@ async function main() {
     const p95 = pairMetric(Number(baselineOp.summary?.p95Ms), Number(currentOp.summary?.p95Ms));
     const mean = pairMetric(Number(baselineOp.summary?.meanMs), Number(currentOp.summary?.meanMs));
 
+    const baselineSamples = baselineOp.samplesMs;
+    const currentSamples = currentOp.samplesMs;
+    const median = pairMetric(
+      baselineSamples ? medianOf(baselineSamples) : Number.NaN,
+      currentSamples ? medianOf(currentSamples) : Number.NaN
+    );
+    const bootstrap = bootstrapMedianDeltaCI(baselineSamples, currentSamples);
+
     // Flag operations where either run has high coefficient of variation.
     // A high CV means the samples are spread out, making any % delta unreliable.
-    const baselineCV = coefficientOfVariation(baselineOp.samplesMs);
-    const currentCV = coefficientOfVariation(currentOp.samplesMs);
+    const baselineCV = coefficientOfVariation(baselineSamples);
+    const currentCV = coefficientOfVariation(currentSamples);
     const noisy =
       (baselineCV !== null && baselineCV > CV_THRESHOLD) || (currentCV !== null && currentCV > CV_THRESHOLD);
 
-    // Treat baseline=0 → current>0 as a hard regression (delta becomes +Infinity).
-    // Also require the absolute change to exceed minAbsoluteDeltaMs to avoid flagging
-    // sub-millisecond jitter on fast operations as regressions.
-    const delta = p95.delta;
+    // Gate criterion: lower bound of bootstrap CI on median delta must exceed the
+    // threshold. This filters out apparent regressions caused by sample variance:
+    // a true regression is one where even the pessimistic edge of the CI is above
+    // the threshold. Also require the absolute median change to exceed
+    // minAbsoluteDeltaMs to avoid flagging sub-millisecond jitter.
     const minAbsDelta = BENCHMARK_REGRESSION_GATE.minAbsoluteDeltaMs;
-    const absoluteP95Delta =
-      p95.baseline !== null && p95.current !== null ? Math.abs(p95.current - p95.baseline) : null;
-    const exceedsPercent = delta !== null && (!Number.isFinite(delta) || delta > threshold);
-    const exceedsAbsolute = absoluteP95Delta === null || absoluteP95Delta >= minAbsDelta;
-    const meanDelta = mean.delta;
-    const meanCorroborates =
-      meanDelta !== null &&
-      (!Number.isFinite(meanDelta) || meanDelta > BENCHMARK_REGRESSION_GATE.meanCorroborationPercent);
-    const isRegression = exceedsPercent && exceedsAbsolute && meanCorroborates;
-    const isWarn = !isRegression && (delta === null || delta >= threshold / 2);
+    const absoluteMedianDelta =
+      median.baseline !== null && median.current !== null ? Math.abs(median.current - median.baseline) : null;
+    const exceedsAbsolute = absoluteMedianDelta === null || absoluteMedianDelta >= minAbsDelta;
+    const ciLower = bootstrap?.ciLowerPercent ?? null;
+    const ciExceedsThreshold = ciLower !== null && (!Number.isFinite(ciLower) || ciLower > threshold);
+    const isRegression = ciExceedsThreshold && exceedsAbsolute;
+    // Warn when the point estimate exceeds threshold but the CI lower bound
+    // doesn't — i.e., the regression might be real but isn't statistically robust.
+    const observedExceeds =
+      bootstrap !== null &&
+      (!Number.isFinite(bootstrap.medianDeltaPercent) || bootstrap.medianDeltaPercent > threshold);
+    const isWarn = !isRegression && observedExceeds && exceedsAbsolute;
 
     const row: ComparisonRow = {
       operationId,
       p95,
       mean,
+      median,
+      bootstrap,
       status: isRegression ? "FAIL" : isWarn ? "WARN" : "PASS",
       noisy,
     };

--- a/apps/benchmark/scripts/compare-benchmark-results.ts
+++ b/apps/benchmark/scripts/compare-benchmark-results.ts
@@ -106,7 +106,7 @@ function renderMarkdown(summary: ComparisonSummary, threshold: number): string {
     `| :-- | :-- |`,
     `| **Gate metric** | p95 latency |`,
     `| **Gate mode** | ${gateIcon} ${gateLabel} |`,
-    `| **Regression threshold** | +${threshold}% |`,
+    `| **Regression threshold** | +${threshold}% and ≥${BENCHMARK_REGRESSION_GATE.minAbsoluteDeltaMs}ms absolute |`,
     `| **Compared operations** | ${summary.rows.length} |`,
     `| **Regressions** | ${summary.regressions.length > 0 ? `⚠️ ${summary.regressions.length}` : `${summary.regressions.length}`} |`,
     `| **Added / Removed** | ${summary.addedOperations.length} / ${summary.removedOperations.length} |`,
@@ -215,14 +215,6 @@ function getComparisonNotices(baseline: BenchmarkRun, current: BenchmarkRun): st
     );
   }
 
-  if (baseline.platform !== current.platform) {
-    const bl = baseline.platform ?? "unknown";
-    const cl = current.platform ?? "unknown";
-    notices.push(
-      `Baseline and current runs were captured on different platforms (\`${bl}\` vs \`${cl}\`); absolute timings are not comparable, so this comparison is advisory.`
-    );
-  }
-
   return notices;
 }
 
@@ -288,8 +280,15 @@ async function main() {
       (baselineCV !== null && baselineCV > CV_THRESHOLD) || (currentCV !== null && currentCV > CV_THRESHOLD);
 
     // Treat baseline=0 → current>0 as a hard regression (delta becomes +Infinity).
+    // Also require the absolute change to exceed minAbsoluteDeltaMs to avoid flagging
+    // sub-millisecond jitter on fast operations as regressions.
     const delta = p95.delta;
-    const isRegression = delta !== null && (!Number.isFinite(delta) || delta > threshold);
+    const minAbsDelta = BENCHMARK_REGRESSION_GATE.minAbsoluteDeltaMs;
+    const absoluteP95Delta =
+      p95.baseline !== null && p95.current !== null ? Math.abs(p95.current - p95.baseline) : null;
+    const exceedsPercent = delta !== null && (!Number.isFinite(delta) || delta > threshold);
+    const exceedsAbsolute = absoluteP95Delta === null || absoluteP95Delta >= minAbsDelta;
+    const isRegression = exceedsPercent && exceedsAbsolute;
     const isWarn = !isRegression && (delta === null || delta >= threshold / 2);
 
     const row: ComparisonRow = {
@@ -322,7 +321,7 @@ async function main() {
     regressions,
     addedOperations,
     removedOperations,
-    shouldFail: !isAdvisory && (regressions.length > 0 || removedOperations.length > 0),
+    shouldFail: regressions.length > 0 || removedOperations.length > 0,
   };
 
   const markdown = renderMarkdown(summary, threshold);

--- a/apps/benchmark/scripts/compare-benchmark-results.ts
+++ b/apps/benchmark/scripts/compare-benchmark-results.ts
@@ -110,7 +110,7 @@ function renderMarkdown(summary: ComparisonSummary, threshold: number): string {
   const lines: string[] = [
     "## Benchmark Regression Report",
     "",
-    `| | |`,
+    `| Summary | |`,
     `| :-- | :-- |`,
     `| **Gate metric** | p95 latency |`,
     `| **Gate mode** | ${gateIcon} ${gateLabel} |`,

--- a/apps/benchmark/scripts/compare-benchmark-results.ts
+++ b/apps/benchmark/scripts/compare-benchmark-results.ts
@@ -178,6 +178,13 @@ function formatDelta(value: number | null, threshold: number): string {
   return formatted;
 }
 
+function formatDeltaCompact(value: number | null): string {
+  if (value === null) return "n/a";
+  if (!Number.isFinite(value)) return value > 0 ? "+∞" : "-∞";
+  const sign = value > 0 ? "+" : "";
+  return `${sign}${value.toFixed(2)}%`;
+}
+
 function formatCIBound(value: number): string {
   if (!Number.isFinite(value)) return value > 0 ? "+∞" : "-∞";
   const sign = value > 0 ? "+" : "";
@@ -209,13 +216,14 @@ function pairMetric(baseline: number, current: number): MetricPair {
 }
 
 function renderMarkdown(summary: ComparisonSummary, threshold: number): string {
-  // Derive the gate state from the actual outcome (shouldFail) first so the
-  // displayed label matches CI gating behavior. Notices are surfaced as a
-  // secondary "advisory" annotation rather than overriding the primary state.
-  const gateIcon = summary.shouldFail ? "❌" : "✅";
-  const baseLabel = summary.shouldFail ? "FAILED" : "passed";
-  const advisorySuffix = summary.notices.length > 0 ? " — ℹ️ advisory notes" : "";
-  const gateLabel = `${baseLabel}${advisorySuffix}`;
+  const noisyRegressions = summary.rows.filter((r) => r.status === "FAIL" && r.noisy).length;
+  const potentialRegressions = summary.rows.filter((r) => r.status === "WARN").length;
+
+  const gateLabel = summary.isAdvisory
+    ? "ℹ️ advisory only (non-blocking)"
+    : summary.shouldFail
+      ? "❌ failed"
+      : "✅ passed";
 
   const lines: string[] = [
     "## Benchmark Regression Report",
@@ -223,10 +231,12 @@ function renderMarkdown(summary: ComparisonSummary, threshold: number): string {
     `| Summary | |`,
     `| :-- | :-- |`,
     `| **Gate metric** | bootstrap 95% CI on median delta |`,
-    `| **Gate mode** | ${gateIcon} ${gateLabel} |`,
+    `| **Gate mode** | ${gateLabel} |`,
     `| **Regression threshold** | CI lower bound > +${threshold}% and ≥${BENCHMARK_REGRESSION_GATE.minAbsoluteDeltaMs}ms absolute median change |`,
     `| **Compared operations** | ${summary.rows.length} |`,
-    `| **Regressions** | ${summary.regressions.length > 0 ? `⚠️ ${summary.regressions.length}` : `${summary.regressions.length}`} |`,
+    `| **Blocking regressions** | ${summary.regressions.length} |`,
+    `| **Potential regressions** | ${potentialRegressions} |`,
+    `| **Noisy regressions (non-blocking)** | ${noisyRegressions} |`,
     `| **Added / Removed** | ${summary.addedOperations.length} / ${summary.removedOperations.length} |`,
     "",
   ];
@@ -234,12 +244,19 @@ function renderMarkdown(summary: ComparisonSummary, threshold: number): string {
   if (summary.notices.length > 0) {
     lines.push("> [!NOTE]");
     for (const notice of summary.notices) lines.push(`> ${notice}`);
+    lines.push("> Merge is not blocked while advisory notices are present.");
     lines.push("");
   }
 
+  lines.push("> [!TIP]");
   lines.push(
-    "| Status | Operation | Median Δ (95% CI) | Baseline median | Current median | Δ p95 | Δ mean |",
-    "| :---: | :-- | :--- | ---: | ---: | ---: | ---: |"
+    "> Gate status is based only on the median CI column below. p95/mean are context metrics and can disagree."
+  );
+  lines.push("");
+
+  lines.push(
+    "| Status | Operation | Gate decision | Median Δ (95% CI) | Baseline median | Current median |",
+    "| :---: | :-- | :-- | :--- | ---: | ---: |"
   );
 
   for (const row of summary.rows) {
@@ -252,15 +269,33 @@ function renderMarkdown(summary: ComparisonSummary, threshold: number): string {
           ? "\uD83D\uDFE1"
           : "\uD83D\uDFE2";
     const noisyTag = row.noisy ? " \uD83C\uDFB2" : "";
+    const decision =
+      row.status === "FAIL"
+        ? row.noisy
+          ? `CI lower > +${threshold}%, but high variance (non-blocking)`
+          : `CI lower > +${threshold}%`
+        : row.status === "WARN"
+          ? `Point estimate > +${threshold}% but CI lower <= +${threshold}%`
+          : `CI lower <= +${threshold}%`;
     const ciCell = row.bootstrap
       ? `${formatDelta(row.bootstrap.medianDeltaPercent, threshold)} (${formatCIBound(row.bootstrap.ciLowerPercent)} … ${formatCIBound(row.bootstrap.ciUpperPercent)})`
       : "n/a";
-    const deltaP95 = formatDelta(row.p95.delta, threshold);
-    const deltaMean = formatDelta(row.mean.delta, threshold);
     lines.push(
-      `| ${statusIcon} | \`${row.operationId}\`${noisyTag} | ${ciCell} | ${formatMetric(row.median.baseline)} | ${formatMetric(row.median.current)} | ${deltaP95} | ${deltaMean} |`
+      `| ${statusIcon} | \`${row.operationId}\`${noisyTag} | ${decision} | ${ciCell} | ${formatMetric(row.median.baseline)} | ${formatMetric(row.median.current)} |`
     );
   }
+
+  lines.push("");
+  lines.push("<details><summary>Context Metrics (Not Used For Gate)</summary>");
+  lines.push("");
+  lines.push("| Operation | Δ p95 | Δ mean |");
+  lines.push("| :-- | ---: | ---: |");
+  for (const row of summary.rows) {
+    lines.push(
+      `| \`${row.operationId}\` | ${formatDeltaCompact(row.p95.delta)} | ${formatDeltaCompact(row.mean.delta)} |`
+    );
+  }
+  lines.push("", "</details>");
 
   for (const [heading, ids] of [
     ["Added Operations", summary.addedOperations],
@@ -279,9 +314,9 @@ function renderMarkdown(summary: ComparisonSummary, threshold: number): string {
   lines.push("<details><summary>Legend</summary>", "");
   lines.push("| Symbol | Meaning |");
   lines.push("| :---: | :-- |");
-  lines.push("| 🟢 | Pass — CI lower bound is within threshold |");
+  lines.push(`| 🟢 | Pass — CI lower <= +${threshold}% |`);
   lines.push("| 🟡 | Warn — point estimate exceeds threshold but CI lower bound does not (likely noise) |");
-  lines.push("| 🔴 | Fail — even pessimistic edge of CI exceeds threshold |");
+  lines.push(`| 🔴 | Fail — CI lower > +${threshold}% |`);
   if (hasNoisyFail) {
     lines.push("| 🟠 | Fail but noisy — high variance makes this unreliable |");
   }

--- a/apps/benchmark/scripts/compare-benchmark-results.ts
+++ b/apps/benchmark/scripts/compare-benchmark-results.ts
@@ -28,6 +28,7 @@ interface ComparisonRow {
   p95: MetricPair;
   mean: MetricPair;
   status: "PASS" | "WARN" | "FAIL";
+  noisy?: boolean;
 }
 
 interface ComparisonSummary {
@@ -46,15 +47,28 @@ interface ComparisonSummary {
 
 const round = (value: number) => Number(value.toFixed(3));
 
+/** Coefficient of variation (stdDev / mean). High CV → noisy measurement. */
+function coefficientOfVariation(samples: number[] | undefined): number | null {
+  if (!samples || samples.length < 2) return null;
+  const n = samples.length;
+  const mean = samples.reduce((s, v) => s + v, 0) / n;
+  if (mean === 0) return null;
+  const variance = samples.reduce((s, v) => s + (v - mean) ** 2, 0) / (n - 1);
+  return Math.sqrt(variance) / mean;
+}
+
 function formatMetric(value: number | null): string {
   return value === null ? "n/a" : String(value);
 }
 
-function formatPercent(value: number | null): string {
+function formatDelta(value: number | null): string {
   if (value === null) return "n/a";
-  if (!Number.isFinite(value)) return "inf";
+  if (!Number.isFinite(value)) return "∞";
   const sign = value > 0 ? "+" : "";
-  return `${sign}${value.toFixed(2)}%`;
+  const formatted = `${sign}${value.toFixed(2)}%`;
+  if (value > 10) return `**${formatted}** 📈`;
+  if (value < -10) return `**${formatted}** 📉`;
+  return formatted;
 }
 
 function pairMetric(baseline: number, current: number): MetricPair {
@@ -82,32 +96,41 @@ function pairMetric(baseline: number, current: number): MetricPair {
 }
 
 function renderMarkdown(summary: ComparisonSummary, threshold: number): string {
+  const gateIcon = summary.isAdvisory ? "ℹ️" : summary.shouldFail ? "❌" : "✅";
+  const gateLabel = summary.isAdvisory ? "advisory" : summary.shouldFail ? "enforcing — FAILED" : "enforcing — passed";
+
   const lines: string[] = [
     "## Benchmark Regression Report",
     "",
-    "- Gate metric: p95 latency",
-    `- Gate mode: ${summary.isAdvisory ? "advisory" : "enforcing"}`,
-    `- Regression threshold: +${threshold}%`,
-    `- Compared operations: ${summary.rows.length}`,
-    `- Regressions: ${summary.regressions.length}`,
-    `- Added operations: ${summary.addedOperations.length}`,
-    `- Removed operations: ${summary.removedOperations.length}`,
+    `| | |`,
+    `| :-- | :-- |`,
+    `| **Gate metric** | p95 latency |`,
+    `| **Gate mode** | ${gateIcon} ${gateLabel} |`,
+    `| **Regression threshold** | +${threshold}% |`,
+    `| **Compared operations** | ${summary.rows.length} |`,
+    `| **Regressions** | ${summary.regressions.length > 0 ? `⚠️ ${summary.regressions.length}` : `${summary.regressions.length}`} |`,
+    `| **Added / Removed** | ${summary.addedOperations.length} / ${summary.removedOperations.length} |`,
     "",
   ];
 
   if (summary.notices.length > 0) {
-    for (const notice of summary.notices) lines.push(`- Notice: ${notice}`);
+    lines.push("> [!NOTE]");
+    for (const notice of summary.notices) lines.push(`> ${notice}`);
     lines.push("");
   }
 
   lines.push(
-    "| Operation | Baseline p95 (ms) | Current p95 (ms) | Delta p95 | Baseline mean (ms) | Current mean (ms) | Delta mean | Status |",
-    "| --- | ---: | ---: | ---: | ---: | ---: | ---: | :---: |"
+    "| Status | Operation | Baseline p95 | Current p95 | Δ p95 | Baseline mean | Current mean | Δ mean |",
+    "| :---: | :-- | ---: | ---: | ---: | ---: | ---: | ---: |"
   );
 
   for (const row of summary.rows) {
+    const statusIcon = row.status === "FAIL" ? (row.noisy ? "🟠" : "🔴") : row.status === "WARN" ? "🟡" : "🟢";
+    const noisyTag = row.noisy ? " 🎲" : "";
+    const deltaP95 = formatDelta(row.p95.delta);
+    const deltaMean = formatDelta(row.mean.delta);
     lines.push(
-      `| ${row.operationId} | ${formatMetric(row.p95.baseline)} | ${formatMetric(row.p95.current)} | ${formatPercent(row.p95.delta)} | ${formatMetric(row.mean.baseline)} | ${formatMetric(row.mean.current)} | ${formatPercent(row.mean.delta)} | ${row.status} |`
+      `| ${statusIcon} | \`${row.operationId}\`${noisyTag} | ${formatMetric(row.p95.baseline)} | ${formatMetric(row.p95.current)} | ${deltaP95} | ${formatMetric(row.mean.baseline)} | ${formatMetric(row.mean.current)} | ${deltaMean} |`
     );
   }
 
@@ -117,9 +140,26 @@ function renderMarkdown(summary: ComparisonSummary, threshold: number): string {
   ] as const) {
     if (ids.length > 0) {
       lines.push("", `### ${heading}`, "");
-      for (const id of ids) lines.push(`- ${id}`);
+      for (const id of ids) lines.push(`- \`${id}\``);
     }
   }
+
+  const hasNoisy = summary.rows.some((r) => r.noisy);
+
+  lines.push("");
+  lines.push("<details><summary>Legend</summary>", "");
+  lines.push("| Symbol | Meaning |");
+  lines.push("| :---: | :-- |");
+  lines.push("| 🟢 | Pass — within threshold |");
+  lines.push("| 🟡 | Warn — approaching threshold |");
+  lines.push("| 🔴 | Fail — exceeds threshold |");
+  if (hasNoisy) {
+    lines.push("| 🟠 | Fail but noisy — high variance makes this unreliable |");
+    lines.push("| 🎲 | High coefficient of variation (CV > 30%) — samples are spread out |");
+  }
+  lines.push("| 📈 | Regression > 10% |");
+  lines.push("| 📉 | Improvement > 10% |");
+  lines.push("", "</details>");
 
   lines.push("", `_Generated at ${new Date().toISOString()}_`);
   return `${lines.join("\n")}\n`;
@@ -239,6 +279,14 @@ async function main() {
     const p95 = pairMetric(Number(baselineOp.summary?.p95Ms), Number(currentOp.summary?.p95Ms));
     const mean = pairMetric(Number(baselineOp.summary?.meanMs), Number(currentOp.summary?.meanMs));
 
+    // Flag operations where either run has high coefficient of variation (CV > 0.3).
+    // A high CV means the samples are spread out, making any % delta unreliable.
+    const CV_THRESHOLD = 0.3;
+    const baselineCV = coefficientOfVariation(baselineOp.samplesMs);
+    const currentCV = coefficientOfVariation(currentOp.samplesMs);
+    const noisy =
+      (baselineCV !== null && baselineCV > CV_THRESHOLD) || (currentCV !== null && currentCV > CV_THRESHOLD);
+
     // Treat baseline=0 → current>0 as a hard regression (delta becomes +Infinity).
     const delta = p95.delta;
     const isRegression = delta !== null && (!Number.isFinite(delta) || delta > threshold);
@@ -249,9 +297,10 @@ async function main() {
       p95,
       mean,
       status: isRegression ? "FAIL" : isWarn ? "WARN" : "PASS",
+      noisy,
     };
     rows.push(row);
-    if (isRegression) regressions.push(row);
+    if (isRegression && !noisy) regressions.push(row);
   }
 
   rows.sort((a, b) => a.operationId.localeCompare(b.operationId));

--- a/apps/benchmark/scripts/compare-benchmark-results.ts
+++ b/apps/benchmark/scripts/compare-benchmark-results.ts
@@ -11,6 +11,7 @@ interface BenchmarkOperation {
 
 interface BenchmarkRun {
   id?: string;
+  browser?: string;
   operations?: BenchmarkOperation[];
 }
 
@@ -173,7 +174,31 @@ function getComparisonNotices(baseline: BenchmarkRun, current: BenchmarkRun): st
     );
   }
 
+  const baselinePlatform = getPlatformToken(baseline.browser);
+  const currentPlatform = getPlatformToken(current.browser);
+  if (baselinePlatform && currentPlatform && baselinePlatform !== currentPlatform) {
+    notices.push(
+      `Baseline and current runs were captured on different platforms (\`${baselinePlatform}\` vs \`${currentPlatform}\`); absolute timings are not comparable, so this comparison is advisory.`
+    );
+  }
+
   return notices;
+}
+
+/**
+ * Extracts a coarse platform token ("Macintosh", "Linux", "Windows", "Android", "iOS")
+ * from a browser User-Agent string. Returns null if the UA is missing or unrecognised.
+ * Used to detect when baseline and current runs come from different machines (e.g. a
+ * fast laptop baseline vs a slower CI runner) — a scenario where regression % is meaningless.
+ */
+function getPlatformToken(userAgent: string | undefined): string | null {
+  if (!userAgent) return null;
+  if (/Macintosh|Mac OS X/i.test(userAgent)) return "Macintosh";
+  if (/Windows/i.test(userAgent)) return "Windows";
+  if (/Android/i.test(userAgent)) return "Android";
+  if (/iPhone|iPad|iOS/i.test(userAgent)) return "iOS";
+  if (/Linux|X11/i.test(userAgent)) return "Linux";
+  return null;
 }
 
 async function writeOutput(filePath: string | undefined, content: string): Promise<void> {

--- a/apps/benchmark/scripts/compare-benchmark-results.ts
+++ b/apps/benchmark/scripts/compare-benchmark-results.ts
@@ -423,7 +423,7 @@ function getComparisonNotices(baseline: BenchmarkRun, current: BenchmarkRun): st
       notices.push(`${label} sample counts are missing or inconsistent across operations.`);
     } else if (count < minSamples) {
       notices.push(
-        `${label} only has ${count} measured samples per operation; meaningful p95 gating starts at ${minSamples}.`
+        `${label} only has ${count} measured samples per operation; reliable median-delta bootstrap CI gating starts at ${minSamples}.`
       );
     }
   }

--- a/apps/benchmark/scripts/compare-benchmark-results.ts
+++ b/apps/benchmark/scripts/compare-benchmark-results.ts
@@ -47,6 +47,9 @@ interface ComparisonSummary {
 
 const round = (value: number) => Number(value.toFixed(3));
 
+/** Coefficient of variation threshold above which a measurement is flagged as noisy. */
+const CV_THRESHOLD = 0.3;
+
 /** Coefficient of variation (stdDev / mean). High CV → noisy measurement. */
 function coefficientOfVariation(samples: number[] | undefined): number | null {
   if (!samples || samples.length < 2) return null;
@@ -96,8 +99,13 @@ function pairMetric(baseline: number, current: number): MetricPair {
 }
 
 function renderMarkdown(summary: ComparisonSummary, threshold: number): string {
-  const gateIcon = summary.isAdvisory ? "ℹ️" : summary.shouldFail ? "❌" : "✅";
-  const gateLabel = summary.isAdvisory ? "advisory" : summary.shouldFail ? "enforcing — FAILED" : "enforcing — passed";
+  // Derive the gate state from the actual outcome (shouldFail) first so the
+  // displayed label matches CI gating behavior. Notices are surfaced as a
+  // secondary "advisory" annotation rather than overriding the primary state.
+  const gateIcon = summary.shouldFail ? "❌" : "✅";
+  const baseLabel = summary.shouldFail ? "FAILED" : "passed";
+  const advisorySuffix = summary.notices.length > 0 ? " — ℹ️ advisory notes" : "";
+  const gateLabel = `${baseLabel}${advisorySuffix}`;
 
   const lines: string[] = [
     "## Benchmark Regression Report",
@@ -155,7 +163,9 @@ function renderMarkdown(summary: ComparisonSummary, threshold: number): string {
   lines.push("| 🔴 | Fail — exceeds threshold |");
   if (hasNoisy) {
     lines.push("| 🟠 | Fail but noisy — high variance makes this unreliable |");
-    lines.push("| 🎲 | High coefficient of variation (CV > 30%) — samples are spread out |");
+    lines.push(
+      `| 🎲 | High coefficient of variation (CV > ${(CV_THRESHOLD * 100).toFixed(0)}%) — samples are spread out |`
+    );
   }
   lines.push("| 📈 | Regression > 10% |");
   lines.push("| 📉 | Improvement > 10% |");
@@ -271,9 +281,8 @@ async function main() {
     const p95 = pairMetric(Number(baselineOp.summary?.p95Ms), Number(currentOp.summary?.p95Ms));
     const mean = pairMetric(Number(baselineOp.summary?.meanMs), Number(currentOp.summary?.meanMs));
 
-    // Flag operations where either run has high coefficient of variation (CV > 0.3).
+    // Flag operations where either run has high coefficient of variation.
     // A high CV means the samples are spread out, making any % delta unreliable.
-    const CV_THRESHOLD = 0.3;
     const baselineCV = coefficientOfVariation(baselineOp.samplesMs);
     const currentCV = coefficientOfVariation(currentOp.samplesMs);
     const noisy =

--- a/apps/benchmark/scripts/compare-benchmark-results.ts
+++ b/apps/benchmark/scripts/compare-benchmark-results.ts
@@ -141,7 +141,7 @@ function bootstrapMedianDeltaCI(
     }
   }
 
-  replicateDeltas.sort((a, b) => a - b);
+  replicateDeltas.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
   const lowerIdx = Math.floor(0.025 * iterations);
   const upperIdx = Math.min(iterations - 1, Math.floor(0.975 * iterations));
 

--- a/apps/benchmark/scripts/compare-benchmark-results.ts
+++ b/apps/benchmark/scripts/compare-benchmark-results.ts
@@ -105,9 +105,20 @@ function bootstrapMedianDeltaCI(
 
   const baselineMedian = medianOf(baselineSamples);
   const currentMedian = medianOf(currentSamples);
-  if (!Number.isFinite(baselineMedian) || baselineMedian === 0) return null;
+  if (!Number.isFinite(baselineMedian)) return null;
 
-  const observedDelta = ((currentMedian - baselineMedian) / baselineMedian) * 100;
+  // Zero-baseline ops (e.g. sub-millisecond ops measured as 0) are still
+  // comparable: any non-zero current is an unbounded change. Downstream gating
+  // requires |median delta| ≥ minAbsoluteDeltaMs, so micro-jitter still gets
+  // filtered out and we don't flag noise.
+  let observedDelta: number;
+  if (baselineMedian === 0 && currentMedian === 0) {
+    observedDelta = 0;
+  } else if (baselineMedian === 0) {
+    observedDelta = currentMedian > 0 ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY;
+  } else {
+    observedDelta = ((currentMedian - baselineMedian) / baselineMedian) * 100;
+  }
 
   const replicateDeltas: number[] = new Array(iterations);
   const baselineN = baselineSamples.length;
@@ -157,13 +168,13 @@ function formatMetric(value: number | null): string {
   return value === null ? "n/a" : String(value);
 }
 
-function formatDelta(value: number | null): string {
+function formatDelta(value: number | null, threshold: number): string {
   if (value === null) return "n/a";
   if (!Number.isFinite(value)) return value > 0 ? "+∞" : "-∞";
   const sign = value > 0 ? "+" : "";
   const formatted = `${sign}${value.toFixed(2)}%`;
-  if (value > 10) return `**${formatted}** 📈`;
-  if (value < -10) return `**${formatted}** 📉`;
+  if (value > threshold) return `**${formatted}** 📈`;
+  if (value < -threshold) return `**${formatted}** 📉`;
   return formatted;
 }
 
@@ -242,10 +253,10 @@ function renderMarkdown(summary: ComparisonSummary, threshold: number): string {
           : "\uD83D\uDFE2";
     const noisyTag = row.noisy ? " \uD83C\uDFB2" : "";
     const ciCell = row.bootstrap
-      ? `${formatDelta(row.bootstrap.medianDeltaPercent)} (${formatCIBound(row.bootstrap.ciLowerPercent)} … ${formatCIBound(row.bootstrap.ciUpperPercent)})`
+      ? `${formatDelta(row.bootstrap.medianDeltaPercent, threshold)} (${formatCIBound(row.bootstrap.ciLowerPercent)} … ${formatCIBound(row.bootstrap.ciUpperPercent)})`
       : "n/a";
-    const deltaP95 = formatDelta(row.p95.delta);
-    const deltaMean = formatDelta(row.mean.delta);
+    const deltaP95 = formatDelta(row.p95.delta, threshold);
+    const deltaMean = formatDelta(row.mean.delta, threshold);
     lines.push(
       `| ${statusIcon} | \`${row.operationId}\`${noisyTag} | ${ciCell} | ${formatMetric(row.median.baseline)} | ${formatMetric(row.median.current)} | ${deltaP95} | ${deltaMean} |`
     );
@@ -279,8 +290,8 @@ function renderMarkdown(summary: ComparisonSummary, threshold: number): string {
       `| 🎲 | High coefficient of variation (CV > ${(CV_THRESHOLD * 100).toFixed(0)}%) — samples are spread out |`
     );
   }
-  lines.push("| 📈 | Regression > 10% |");
-  lines.push("| 📉 | Improvement > 10% |");
+  lines.push(`| 📈 | Regression > ${threshold}% |`);
+  lines.push(`| 📉 | Improvement > ${threshold}% |`);
   lines.push("", "</details>");
 
   lines.push("", `_Generated at ${new Date().toISOString()}_`);
@@ -418,13 +429,15 @@ async function main() {
       median.baseline !== null && median.current !== null ? Math.abs(median.current - median.baseline) : null;
     const exceedsAbsolute = absoluteMedianDelta === null || absoluteMedianDelta >= minAbsDelta;
     const ciLower = bootstrap?.ciLowerPercent ?? null;
-    const ciExceedsThreshold = ciLower !== null && (!Number.isFinite(ciLower) || ciLower > threshold);
+    // Only positive infinity counts as exceeding the threshold; -Infinity is a
+    // huge improvement, not a regression.
+    const ciExceedsThreshold = ciLower !== null && (ciLower === Number.POSITIVE_INFINITY || ciLower > threshold);
     const isRegression = ciExceedsThreshold && exceedsAbsolute;
     // Warn when the point estimate exceeds threshold but the CI lower bound
     // doesn't — i.e., the regression might be real but isn't statistically robust.
     const observedExceeds =
       bootstrap !== null &&
-      (!Number.isFinite(bootstrap.medianDeltaPercent) || bootstrap.medianDeltaPercent > threshold);
+      (bootstrap.medianDeltaPercent === Number.POSITIVE_INFINITY || bootstrap.medianDeltaPercent > threshold);
     const isWarn = !isRegression && observedExceeds && exceedsAbsolute;
 
     const row: ComparisonRow = {
@@ -459,7 +472,9 @@ async function main() {
     regressions,
     addedOperations,
     removedOperations,
-    shouldFail: regressions.length > 0 || removedOperations.length > 0,
+    // Advisory comparisons (e.g. mismatched sample counts, missing samplesMs)
+    // never block the gate — they're flagged as informational only.
+    shouldFail: !isAdvisory && (regressions.length > 0 || removedOperations.length > 0),
   };
 
   const markdown = renderMarkdown(summary, threshold);

--- a/apps/benchmark/scripts/compare-benchmark-results.ts
+++ b/apps/benchmark/scripts/compare-benchmark-results.ts
@@ -152,7 +152,8 @@ function renderMarkdown(summary: ComparisonSummary, threshold: number): string {
     }
   }
 
-  const hasNoisy = summary.rows.some((r) => r.noisy);
+  const hasNoisyFail = summary.rows.some((r) => r.noisy && r.status === "FAIL");
+  const hasHighCV = summary.rows.some((r) => r.noisy);
 
   lines.push("");
   lines.push("<details><summary>Legend</summary>", "");
@@ -161,8 +162,10 @@ function renderMarkdown(summary: ComparisonSummary, threshold: number): string {
   lines.push("| 🟢 | Pass — within threshold |");
   lines.push("| 🟡 | Warn — approaching threshold |");
   lines.push("| 🔴 | Fail — exceeds threshold |");
-  if (hasNoisy) {
+  if (hasNoisyFail) {
     lines.push("| 🟠 | Fail but noisy — high variance makes this unreliable |");
+  }
+  if (hasHighCV) {
     lines.push(
       `| 🎲 | High coefficient of variation (CV > ${(CV_THRESHOLD * 100).toFixed(0)}%) — samples are spread out |`
     );

--- a/apps/benchmark/scripts/compare-benchmark-results.ts
+++ b/apps/benchmark/scripts/compare-benchmark-results.ts
@@ -293,6 +293,12 @@ function renderMarkdown(summary: ComparisonSummary, threshold: number): string {
   );
 
   for (const row of summary.rows) {
+    const clearSpeedup = isClearSpeedup(row, threshold);
+    const leaningSpeedup =
+      !clearSpeedup &&
+      row.bootstrap !== null &&
+      exceedsThresholdInDirection(row.bootstrap.medianDeltaPercent, threshold, "negative");
+
     const statusIcon =
       row.status === "FAIL"
         ? row.noisy
@@ -300,7 +306,11 @@ function renderMarkdown(summary: ComparisonSummary, threshold: number): string {
           : "\uD83D\uDD34"
         : row.status === "WARN"
           ? "\uD83D\uDFE1"
-          : "\uD83D\uDFE2";
+          : clearSpeedup
+            ? "\uD83D\uDD35"
+            : leaningSpeedup
+              ? "\uD83D\uDFE9"
+              : "\uD83D\uDFE2";
     const noisyTag = row.noisy ? " \uD83C\uDFB2" : "";
     const decision =
       row.status === "FAIL"
@@ -309,7 +319,11 @@ function renderMarkdown(summary: ComparisonSummary, threshold: number): string {
           : `CI lower > +${threshold}%`
         : row.status === "WARN"
           ? `Point estimate > +${threshold}% but CI lower <= +${threshold}%`
-          : `CI lower <= +${threshold}%`;
+          : clearSpeedup
+            ? `CI upper < -${threshold}% (confident speedup)`
+            : leaningSpeedup
+              ? `Median indicates speedup, but CI still overlaps the neutral band`
+              : `CI lower <= +${threshold}%`;
     const medianDelta = row.bootstrap ? formatDeltaCompact(row.bootstrap.medianDeltaPercent) : "n/a";
     const ciRange = row.bootstrap
       ? `${formatCIBound(row.bootstrap.ciLowerPercent)} … ${formatCIBound(row.bootstrap.ciUpperPercent)}`
@@ -350,6 +364,8 @@ function renderMarkdown(summary: ComparisonSummary, threshold: number): string {
   lines.push("| Symbol | Meaning |");
   lines.push("| :---: | :-- |");
   lines.push(`| 🟢 | Pass — CI lower <= +${threshold}% |`);
+  lines.push(`| 🔵 | Clear speedup — CI upper < -${threshold}% |`);
+  lines.push(`| 🟩 | Leaning faster — median shows speedup, but CI still overlaps neutral |`);
   lines.push("| 🟡 | Warn — point estimate exceeds threshold but CI lower bound does not (likely noise) |");
   lines.push(`| 🔴 | Fail — CI lower > +${threshold}% |`);
   if (hasNoisyFail) {

--- a/apps/benchmark/src/app/layout.tsx
+++ b/apps/benchmark/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Analytics } from "@vercel/analytics/next";
 import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
 import "./globals.css";
@@ -20,7 +21,10 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
       className={cn("dark", GeistSans.className, GeistMono.variable, "font-sans")}
       suppressHydrationWarning
     >
-      <body>{children}</body>
+      <body>
+        {children}
+        <Analytics />
+      </body>
     </html>
   );
 }

--- a/apps/benchmark/src/lib/benchmark/config-validation.ts
+++ b/apps/benchmark/src/lib/benchmark/config-validation.ts
@@ -6,7 +6,7 @@ export const BENCHMARK_LIMITS = {
   minWarmupRuns: 0,
   maxWarmupRuns: 8,
   minMeasuredRuns: 1,
-  maxMeasuredRuns: 50,
+  maxMeasuredRuns: 30,
 } as const;
 
 export type SanitizedBenchmarkConfigResult =

--- a/apps/benchmark/src/lib/benchmark/config-validation.ts
+++ b/apps/benchmark/src/lib/benchmark/config-validation.ts
@@ -6,7 +6,7 @@ export const BENCHMARK_LIMITS = {
   minWarmupRuns: 0,
   maxWarmupRuns: 8,
   minMeasuredRuns: 1,
-  maxMeasuredRuns: 30,
+  maxMeasuredRuns: 50,
 } as const;
 
 export type SanitizedBenchmarkConfigResult =

--- a/apps/benchmark/src/lib/benchmark/types.ts
+++ b/apps/benchmark/src/lib/benchmark/types.ts
@@ -28,7 +28,6 @@ export const BENCHMARK_DEFAULT_CONFIG: BenchmarkConfig = {
 
 export const BENCHMARK_REGRESSION_GATE = {
   thresholdPercent: 10,
-  meanCorroborationPercent: 5,
   minMeaningfulP95Samples: 20,
   minAbsoluteDeltaMs: 5,
 } as const;

--- a/apps/benchmark/src/lib/benchmark/types.ts
+++ b/apps/benchmark/src/lib/benchmark/types.ts
@@ -23,7 +23,7 @@ export interface BenchmarkConfig {
 export const BENCHMARK_DEFAULT_CONFIG: BenchmarkConfig = {
   datasetSize: 1000,
   warmupRuns: 2,
-  measuredRuns: 20,
+  measuredRuns: 50,
 };
 
 export const BENCHMARK_REGRESSION_GATE = {

--- a/apps/benchmark/src/lib/benchmark/types.ts
+++ b/apps/benchmark/src/lib/benchmark/types.ts
@@ -28,6 +28,7 @@ export const BENCHMARK_DEFAULT_CONFIG: BenchmarkConfig = {
 
 export const BENCHMARK_REGRESSION_GATE = {
   thresholdPercent: 10,
+  meanCorroborationPercent: 5,
   minMeaningfulP95Samples: 20,
   minAbsoluteDeltaMs: 5,
 } as const;

--- a/apps/benchmark/src/lib/benchmark/types.ts
+++ b/apps/benchmark/src/lib/benchmark/types.ts
@@ -54,6 +54,7 @@ export interface BenchmarkRunResult {
   startedAt: string;
   completedAt: string;
   browser: string;
+  platform?: string;
   config: BenchmarkConfig;
   totalDurationMs: number;
   operations: BenchmarkOperationResult[];

--- a/apps/benchmark/src/lib/benchmark/types.ts
+++ b/apps/benchmark/src/lib/benchmark/types.ts
@@ -29,6 +29,7 @@ export const BENCHMARK_DEFAULT_CONFIG: BenchmarkConfig = {
 export const BENCHMARK_REGRESSION_GATE = {
   thresholdPercent: 10,
   minMeaningfulP95Samples: 20,
+  minAbsoluteDeltaMs: 5,
 } as const;
 
 export interface BenchmarkStatSummary {

--- a/apps/benchmark/src/lib/benchmark/types.ts
+++ b/apps/benchmark/src/lib/benchmark/types.ts
@@ -23,7 +23,7 @@ export interface BenchmarkConfig {
 export const BENCHMARK_DEFAULT_CONFIG: BenchmarkConfig = {
   datasetSize: 1000,
   warmupRuns: 2,
-  measuredRuns: 50,
+  measuredRuns: 30,
 };
 
 export const BENCHMARK_REGRESSION_GATE = {

--- a/apps/benchmark/src/lib/prisma-idb/client/prisma-idb-client.ts
+++ b/apps/benchmark/src/lib/prisma-idb/client/prisma-idb-client.ts
@@ -191,37 +191,70 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
       const todos_opts = (attach_todos === true ? {} : attach_todos) as Record<string, unknown>;
       const todos_sel = todos_opts.select as Record<string, boolean> | undefined;
       const todos_keysToInject = todos_sel ? (["userId"] as string[]).filter((k) => !todos_sel![k]) : [];
+      const todos_take = todos_opts.take as number | undefined;
+      const todos_skip = todos_opts.skip as number | undefined;
+      const todos_cursor = todos_opts.cursor;
+      const todos_distinct = todos_opts.distinct;
       const todos_parentIds = [...new Set(records.map((r) => r.id))];
-      const todos_allRelated = await this.client.todo.findMany(
-        {
-          ...todos_opts,
-          ...(todos_keysToInject.length > 0
-            ? { select: { ...todos_sel, ...Object.fromEntries(todos_keysToInject.map((k) => [k, true])) } }
-            : {}),
-          take: undefined,
-          skip: undefined,
-          where: { userId: { in: todos_parentIds } },
-        },
-        { tx }
-      );
-      const todos_take = attach_todos !== true ? (attach_todos as Prisma.TodoFindManyArgs).take : undefined;
-      const todos_skip = attach_todos !== true ? (attach_todos as Prisma.TodoFindManyArgs).skip : undefined;
       todos_hashMap = new Map<string, unknown[]>();
-      for (const related of todos_allRelated) {
-        const _r = related as Record<string, unknown>;
-        const key = JSON.stringify(_r["userId"]);
-        if (!todos_hashMap!.has(key)) todos_hashMap!.set(key, []);
-        const value =
-          todos_keysToInject.length > 0
-            ? Object.fromEntries(Object.entries(_r).filter(([k]) => !todos_keysToInject.includes(k)))
-            : _r;
-        todos_hashMap!.get(key)!.push(value as unknown);
-      }
-      if (todos_skip !== undefined || todos_take !== undefined) {
-        for (const [key, group] of todos_hashMap!) {
-          const start = todos_skip ?? 0;
-          const end = todos_take !== undefined ? start + todos_take : undefined;
-          todos_hashMap!.set(key, group.slice(start, end));
+      const todos_userWhere = todos_opts.where as Record<string, unknown> | undefined;
+      if (todos_cursor !== undefined || todos_distinct !== undefined) {
+        for (const parentId of todos_parentIds) {
+          const todos_perParentFkWhere = { userId: parentId };
+          const todos_perParentWhere = todos_userWhere
+            ? { AND: [todos_userWhere, todos_perParentFkWhere] }
+            : todos_perParentFkWhere;
+          const children = await this.client.todo.findMany(
+            {
+              ...todos_opts,
+              ...(todos_keysToInject.length > 0
+                ? { select: { ...todos_sel, ...Object.fromEntries(todos_keysToInject.map((k) => [k, true])) } }
+                : {}),
+              where: todos_perParentWhere,
+            },
+            { tx }
+          );
+          const stripped = children.map((c) => {
+            const _r = c as Record<string, unknown>;
+            return todos_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !todos_keysToInject.includes(k)))
+              : _r;
+          });
+          todos_hashMap!.set(JSON.stringify(parentId), stripped as unknown[]);
+        }
+      } else {
+        const todos_fkWhere = { userId: { in: todos_parentIds } };
+        const todos_where = todos_userWhere ? { AND: [todos_userWhere, todos_fkWhere] } : todos_fkWhere;
+        const todos_allRelated = await this.client.todo.findMany(
+          {
+            ...todos_opts,
+            ...(todos_keysToInject.length > 0
+              ? { select: { ...todos_sel, ...Object.fromEntries(todos_keysToInject.map((k) => [k, true])) } }
+              : {}),
+            take: undefined,
+            skip: undefined,
+            where: todos_where,
+          },
+          { tx }
+        );
+        for (const related of todos_allRelated) {
+          const _r = related as Record<string, unknown>;
+          const key = JSON.stringify(_r["userId"]);
+          if (!todos_hashMap!.has(key)) todos_hashMap!.set(key, []);
+          const value =
+            todos_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !todos_keysToInject.includes(k)))
+              : _r;
+          todos_hashMap!.get(key)!.push(value as unknown);
+        }
+        if (todos_skip !== undefined || todos_take !== undefined) {
+          for (const [key, group] of todos_hashMap!) {
+            let sliced = group;
+            if (todos_skip !== undefined) sliced = sliced.slice(todos_skip);
+            if (todos_take !== undefined)
+              sliced = todos_take < 0 ? sliced.slice(todos_take) : sliced.slice(0, todos_take);
+            todos_hashMap!.set(key, sliced);
+          }
         }
       }
     }
@@ -1117,13 +1150,16 @@ class TodoIDBClass extends BaseIDBModelClass<"Todo"> {
       const user_sel = user_opts.select as Record<string, boolean> | undefined;
       const user_keysToInject = user_sel ? (["id"] as string[]).filter((k) => !user_sel![k]) : [];
       const user_fkValues = [...new Set(records.map((r) => r.userId).filter((v) => v !== null && v !== undefined))];
+      const user_userWhere = user_opts.where as Record<string, unknown> | undefined;
+      const user_fkWhere = { id: { in: user_fkValues } };
+      const user_where = user_userWhere ? { AND: [user_userWhere, user_fkWhere] } : user_fkWhere;
       const user_related = await this.client.user.findMany(
         {
           ...user_opts,
           ...(user_keysToInject.length > 0
             ? { select: { ...user_sel, ...Object.fromEntries(user_keysToInject.map((k) => [k, true])) } }
             : {}),
-          where: { id: { in: user_fkValues } },
+          where: user_where,
         },
         { tx }
       );

--- a/apps/benchmark/src/lib/prisma-idb/client/prisma-idb-client.ts
+++ b/apps/benchmark/src/lib/prisma-idb/client/prisma-idb-client.ts
@@ -185,21 +185,54 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
     query?: Q
   ): Promise<Prisma.Result<Prisma.UserDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.UserDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map(async (record) => {
+    const attach_todos = query.select?.todos || query.include?.todos;
+    let todos_hashMap: Map<string, unknown[]> | undefined;
+    if (attach_todos) {
+      const todos_opts = (attach_todos === true ? {} : attach_todos) as Record<string, unknown>;
+      const todos_sel = todos_opts.select as Record<string, boolean> | undefined;
+      const todos_keysToInject = todos_sel ? (["userId"] as string[]).filter((k) => !todos_sel![k]) : [];
+      const todos_parentIds = [...new Set(records.map((r) => r.id))];
+      const todos_allRelated = await this.client.todo.findMany(
+        {
+          ...todos_opts,
+          ...(todos_keysToInject.length > 0
+            ? { select: { ...todos_sel, ...Object.fromEntries(todos_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          take: undefined,
+          skip: undefined,
+          where: { userId: { in: todos_parentIds } },
+        },
+        { tx }
+      );
+      const todos_take = attach_todos !== true ? (attach_todos as Prisma.TodoFindManyArgs).take : undefined;
+      const todos_skip = attach_todos !== true ? (attach_todos as Prisma.TodoFindManyArgs).skip : undefined;
+      todos_hashMap = new Map<string, unknown[]>();
+      for (const related of todos_allRelated) {
+        const _r = related as Record<string, unknown>;
+        const key = JSON.stringify(_r["userId"]);
+        if (!todos_hashMap!.has(key)) todos_hashMap!.set(key, []);
+        const value =
+          todos_keysToInject.length > 0
+            ? Object.fromEntries(Object.entries(_r).filter(([k]) => !todos_keysToInject.includes(k)))
+            : _r;
+        todos_hashMap!.get(key)!.push(value as unknown);
+      }
+      if (todos_skip !== undefined || todos_take !== undefined) {
+        for (const [key, group] of todos_hashMap!) {
+          const start = todos_skip ?? 0;
+          const end = todos_take !== undefined ? start + todos_take : undefined;
+          todos_hashMap!.set(key, group.slice(start, end));
+        }
+      }
+    }
+    const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
-      const attach_todos = query.select?.todos || query.include?.todos;
       if (attach_todos) {
-        unsafeRecord["todos"] = await this.client.todo.findMany(
-          {
-            ...(attach_todos === true ? {} : attach_todos),
-            where: { userId: record.id! },
-          },
-          { tx }
-        );
+        unsafeRecord["todos"] = todos_hashMap!.get(JSON.stringify(record.id)) ?? [];
       }
       return unsafeRecord;
     });
-    return (await Promise.all(recordsWithRelations)) as Prisma.Result<Prisma.UserDelegate, Q, "findFirstOrThrow">[];
+    return recordsWithRelations as Prisma.Result<Prisma.UserDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.UserDelegate, "findMany">["orderBy"],
@@ -1077,21 +1110,43 @@ class TodoIDBClass extends BaseIDBModelClass<"Todo"> {
     query?: Q
   ): Promise<Prisma.Result<Prisma.TodoDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.TodoDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map(async (record) => {
+    const attach_user = query.select?.user || query.include?.user;
+    let user_hashMap: Map<string, unknown> | undefined;
+    if (attach_user) {
+      const user_opts = (attach_user === true ? {} : attach_user) as Record<string, unknown>;
+      const user_sel = user_opts.select as Record<string, boolean> | undefined;
+      const user_keysToInject = user_sel ? (["id"] as string[]).filter((k) => !user_sel![k]) : [];
+      const user_fkValues = [...new Set(records.map((r) => r.userId).filter((v) => v !== null && v !== undefined))];
+      const user_related = await this.client.user.findMany(
+        {
+          ...user_opts,
+          ...(user_keysToInject.length > 0
+            ? { select: { ...user_sel, ...Object.fromEntries(user_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          where: { id: { in: user_fkValues } },
+        },
+        { tx }
+      );
+      user_hashMap = new Map(
+        user_related.map((r) => {
+          const _r = r as Record<string, unknown>;
+          const key = JSON.stringify(_r["id"]);
+          const value =
+            user_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !user_keysToInject.includes(k)))
+              : _r;
+          return [key, value as unknown];
+        })
+      );
+    }
+    const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
-      const attach_user = query.select?.user || query.include?.user;
       if (attach_user) {
-        unsafeRecord["user"] = await this.client.user.findUnique(
-          {
-            ...(attach_user === true ? {} : attach_user),
-            where: { id: record.userId! },
-          },
-          { tx }
-        );
+        unsafeRecord["user"] = user_hashMap!.get(JSON.stringify(record.userId)) ?? null;
       }
       return unsafeRecord;
     });
-    return (await Promise.all(recordsWithRelations)) as Prisma.Result<Prisma.TodoDelegate, Q, "findFirstOrThrow">[];
+    return recordsWithRelations as Prisma.Result<Prisma.TodoDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.TodoDelegate, "findMany">["orderBy"],

--- a/apps/benchmark/src/lib/prisma-idb/client/prisma-idb-client.ts
+++ b/apps/benchmark/src/lib/prisma-idb/client/prisma-idb-client.ts
@@ -186,6 +186,7 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
   ): Promise<Prisma.Result<Prisma.UserDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.UserDelegate, Q, "findFirstOrThrow">[];
     const attach_todos = query.select?.todos || query.include?.todos;
+    if (!attach_todos) return records as Prisma.Result<Prisma.UserDelegate, Q, "findFirstOrThrow">[];
     let todos_hashMap: Map<string, unknown[]> | undefined;
     if (attach_todos) {
       const todos_opts = (attach_todos === true ? {} : attach_todos) as Record<string, unknown>;
@@ -1150,6 +1151,7 @@ class TodoIDBClass extends BaseIDBModelClass<"Todo"> {
   ): Promise<Prisma.Result<Prisma.TodoDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.TodoDelegate, Q, "findFirstOrThrow">[];
     const attach_user = query.select?.user || query.include?.user;
+    if (!attach_user) return records as Prisma.Result<Prisma.TodoDelegate, Q, "findFirstOrThrow">[];
     let user_hashMap: Map<string, unknown> | undefined;
     if (attach_user) {
       const user_opts = (attach_user === true ? {} : attach_user) as Record<string, unknown>;

--- a/apps/benchmark/src/lib/prisma-idb/client/prisma-idb-client.ts
+++ b/apps/benchmark/src/lib/prisma-idb/client/prisma-idb-client.ts
@@ -248,6 +248,9 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
           todos_hashMap!.get(key)!.push(value as unknown);
         }
         if (todos_skip !== undefined || todos_take !== undefined) {
+          if (todos_skip !== undefined && (!Number.isInteger(todos_skip) || todos_skip < 0))
+            throw new Error("skip must be a non-negative integer");
+          if (todos_take !== undefined && !Number.isInteger(todos_take)) throw new Error("take must be an integer");
           for (const [key, group] of todos_hashMap!) {
             let sliced = group;
             if (todos_skip !== undefined) sliced = sliced.slice(todos_skip);
@@ -261,7 +264,10 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
     const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
       if (attach_todos) {
-        unsafeRecord["todos"] = todos_hashMap!.get(JSON.stringify(record.id)) ?? [];
+        unsafeRecord["todos"] = (() => {
+          const _v = todos_hashMap!.get(JSON.stringify(record.id));
+          return _v == null ? [] : structuredClone(_v);
+        })();
       }
       return unsafeRecord;
     });
@@ -1178,7 +1184,10 @@ class TodoIDBClass extends BaseIDBModelClass<"Todo"> {
     const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
       if (attach_user) {
-        unsafeRecord["user"] = user_hashMap!.get(JSON.stringify(record.userId)) ?? null;
+        unsafeRecord["user"] = (() => {
+          const _v = user_hashMap!.get(JSON.stringify(record.userId));
+          return _v == null ? null : structuredClone(_v);
+        })();
       }
       return unsafeRecord;
     });

--- a/apps/benchmark/test/benchmark-ci.spec.ts
+++ b/apps/benchmark/test/benchmark-ci.spec.ts
@@ -45,12 +45,14 @@ test("runs benchmark suite and exports JSON result", async ({ page }) => {
     expect(operation.summary.meanMs).toBeGreaterThanOrEqual(0);
   }
 
+  const resultWithPlatform = { ...parsedResult, platform: process.platform };
+
   const resultPath = resolve(
     process.cwd(),
     process.env.BENCHMARK_RESULT_PATH ?? "../../benchmarks/results/current.json"
   );
   await mkdir(dirname(resultPath), { recursive: true });
-  await writeFile(resultPath, `${JSON.stringify(parsedResult, null, 2)}\n`, "utf8");
+  await writeFile(resultPath, `${JSON.stringify(resultWithPlatform, null, 2)}\n`, "utf8");
 
   test.info().annotations.push({ type: "benchmark-result", description: resultPath });
 });

--- a/apps/pidb-kanban-example/src/lib/prisma-idb/client/prisma-idb-client.ts
+++ b/apps/pidb-kanban-example/src/lib/prisma-idb/client/prisma-idb-client.ts
@@ -641,37 +641,70 @@ class BoardIDBClass extends BaseIDBModelClass<"Board"> {
       const todos_opts = (attach_todos === true ? {} : attach_todos) as Record<string, unknown>;
       const todos_sel = todos_opts.select as Record<string, boolean> | undefined;
       const todos_keysToInject = todos_sel ? (["boardId"] as string[]).filter((k) => !todos_sel![k]) : [];
+      const todos_take = todos_opts.take as number | undefined;
+      const todos_skip = todos_opts.skip as number | undefined;
+      const todos_cursor = todos_opts.cursor;
+      const todos_distinct = todos_opts.distinct;
       const todos_parentIds = [...new Set(records.map((r) => r.id))];
-      const todos_allRelated = await this.client.todo.findMany(
-        {
-          ...todos_opts,
-          ...(todos_keysToInject.length > 0
-            ? { select: { ...todos_sel, ...Object.fromEntries(todos_keysToInject.map((k) => [k, true])) } }
-            : {}),
-          take: undefined,
-          skip: undefined,
-          where: { boardId: { in: todos_parentIds } },
-        },
-        { tx }
-      );
-      const todos_take = attach_todos !== true ? (attach_todos as Prisma.TodoFindManyArgs).take : undefined;
-      const todos_skip = attach_todos !== true ? (attach_todos as Prisma.TodoFindManyArgs).skip : undefined;
       todos_hashMap = new Map<string, unknown[]>();
-      for (const related of todos_allRelated) {
-        const _r = related as Record<string, unknown>;
-        const key = JSON.stringify(_r["boardId"]);
-        if (!todos_hashMap!.has(key)) todos_hashMap!.set(key, []);
-        const value =
-          todos_keysToInject.length > 0
-            ? Object.fromEntries(Object.entries(_r).filter(([k]) => !todos_keysToInject.includes(k)))
-            : _r;
-        todos_hashMap!.get(key)!.push(value as unknown);
-      }
-      if (todos_skip !== undefined || todos_take !== undefined) {
-        for (const [key, group] of todos_hashMap!) {
-          const start = todos_skip ?? 0;
-          const end = todos_take !== undefined ? start + todos_take : undefined;
-          todos_hashMap!.set(key, group.slice(start, end));
+      const todos_userWhere = todos_opts.where as Record<string, unknown> | undefined;
+      if (todos_cursor !== undefined || todos_distinct !== undefined) {
+        for (const parentId of todos_parentIds) {
+          const todos_perParentFkWhere = { boardId: parentId };
+          const todos_perParentWhere = todos_userWhere
+            ? { AND: [todos_userWhere, todos_perParentFkWhere] }
+            : todos_perParentFkWhere;
+          const children = await this.client.todo.findMany(
+            {
+              ...todos_opts,
+              ...(todos_keysToInject.length > 0
+                ? { select: { ...todos_sel, ...Object.fromEntries(todos_keysToInject.map((k) => [k, true])) } }
+                : {}),
+              where: todos_perParentWhere,
+            },
+            { tx }
+          );
+          const stripped = children.map((c) => {
+            const _r = c as Record<string, unknown>;
+            return todos_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !todos_keysToInject.includes(k)))
+              : _r;
+          });
+          todos_hashMap!.set(JSON.stringify(parentId), stripped as unknown[]);
+        }
+      } else {
+        const todos_fkWhere = { boardId: { in: todos_parentIds } };
+        const todos_where = todos_userWhere ? { AND: [todos_userWhere, todos_fkWhere] } : todos_fkWhere;
+        const todos_allRelated = await this.client.todo.findMany(
+          {
+            ...todos_opts,
+            ...(todos_keysToInject.length > 0
+              ? { select: { ...todos_sel, ...Object.fromEntries(todos_keysToInject.map((k) => [k, true])) } }
+              : {}),
+            take: undefined,
+            skip: undefined,
+            where: todos_where,
+          },
+          { tx }
+        );
+        for (const related of todos_allRelated) {
+          const _r = related as Record<string, unknown>;
+          const key = JSON.stringify(_r["boardId"]);
+          if (!todos_hashMap!.has(key)) todos_hashMap!.set(key, []);
+          const value =
+            todos_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !todos_keysToInject.includes(k)))
+              : _r;
+          todos_hashMap!.get(key)!.push(value as unknown);
+        }
+        if (todos_skip !== undefined || todos_take !== undefined) {
+          for (const [key, group] of todos_hashMap!) {
+            let sliced = group;
+            if (todos_skip !== undefined) sliced = sliced.slice(todos_skip);
+            if (todos_take !== undefined)
+              sliced = todos_take < 0 ? sliced.slice(todos_take) : sliced.slice(0, todos_take);
+            todos_hashMap!.set(key, sliced);
+          }
         }
       }
     }
@@ -682,13 +715,16 @@ class BoardIDBClass extends BaseIDBModelClass<"Board"> {
       const user_sel = user_opts.select as Record<string, boolean> | undefined;
       const user_keysToInject = user_sel ? (["id"] as string[]).filter((k) => !user_sel![k]) : [];
       const user_fkValues = [...new Set(records.map((r) => r.userId).filter((v) => v !== null && v !== undefined))];
+      const user_userWhere = user_opts.where as Record<string, unknown> | undefined;
+      const user_fkWhere = { id: { in: user_fkValues } };
+      const user_where = user_userWhere ? { AND: [user_userWhere, user_fkWhere] } : user_fkWhere;
       const user_related = await this.client.user.findMany(
         {
           ...user_opts,
           ...(user_keysToInject.length > 0
             ? { select: { ...user_sel, ...Object.fromEntries(user_keysToInject.map((k) => [k, true])) } }
             : {}),
-          where: { id: { in: user_fkValues } },
+          where: user_where,
         },
         { tx }
       );
@@ -1776,13 +1812,16 @@ class TodoIDBClass extends BaseIDBModelClass<"Todo"> {
       const board_sel = board_opts.select as Record<string, boolean> | undefined;
       const board_keysToInject = board_sel ? (["id"] as string[]).filter((k) => !board_sel![k]) : [];
       const board_fkValues = [...new Set(records.map((r) => r.boardId).filter((v) => v !== null && v !== undefined))];
+      const board_userWhere = board_opts.where as Record<string, unknown> | undefined;
+      const board_fkWhere = { id: { in: board_fkValues } };
+      const board_where = board_userWhere ? { AND: [board_userWhere, board_fkWhere] } : board_fkWhere;
       const board_related = await this.client.board.findMany(
         {
           ...board_opts,
           ...(board_keysToInject.length > 0
             ? { select: { ...board_sel, ...Object.fromEntries(board_keysToInject.map((k) => [k, true])) } }
             : {}),
-          where: { id: { in: board_fkValues } },
+          where: board_where,
         },
         { tx }
       );
@@ -2656,37 +2695,70 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
       const boards_opts = (attach_boards === true ? {} : attach_boards) as Record<string, unknown>;
       const boards_sel = boards_opts.select as Record<string, boolean> | undefined;
       const boards_keysToInject = boards_sel ? (["userId"] as string[]).filter((k) => !boards_sel![k]) : [];
+      const boards_take = boards_opts.take as number | undefined;
+      const boards_skip = boards_opts.skip as number | undefined;
+      const boards_cursor = boards_opts.cursor;
+      const boards_distinct = boards_opts.distinct;
       const boards_parentIds = [...new Set(records.map((r) => r.id))];
-      const boards_allRelated = await this.client.board.findMany(
-        {
-          ...boards_opts,
-          ...(boards_keysToInject.length > 0
-            ? { select: { ...boards_sel, ...Object.fromEntries(boards_keysToInject.map((k) => [k, true])) } }
-            : {}),
-          take: undefined,
-          skip: undefined,
-          where: { userId: { in: boards_parentIds } },
-        },
-        { tx }
-      );
-      const boards_take = attach_boards !== true ? (attach_boards as Prisma.BoardFindManyArgs).take : undefined;
-      const boards_skip = attach_boards !== true ? (attach_boards as Prisma.BoardFindManyArgs).skip : undefined;
       boards_hashMap = new Map<string, unknown[]>();
-      for (const related of boards_allRelated) {
-        const _r = related as Record<string, unknown>;
-        const key = JSON.stringify(_r["userId"]);
-        if (!boards_hashMap!.has(key)) boards_hashMap!.set(key, []);
-        const value =
-          boards_keysToInject.length > 0
-            ? Object.fromEntries(Object.entries(_r).filter(([k]) => !boards_keysToInject.includes(k)))
-            : _r;
-        boards_hashMap!.get(key)!.push(value as unknown);
-      }
-      if (boards_skip !== undefined || boards_take !== undefined) {
-        for (const [key, group] of boards_hashMap!) {
-          const start = boards_skip ?? 0;
-          const end = boards_take !== undefined ? start + boards_take : undefined;
-          boards_hashMap!.set(key, group.slice(start, end));
+      const boards_userWhere = boards_opts.where as Record<string, unknown> | undefined;
+      if (boards_cursor !== undefined || boards_distinct !== undefined) {
+        for (const parentId of boards_parentIds) {
+          const boards_perParentFkWhere = { userId: parentId };
+          const boards_perParentWhere = boards_userWhere
+            ? { AND: [boards_userWhere, boards_perParentFkWhere] }
+            : boards_perParentFkWhere;
+          const children = await this.client.board.findMany(
+            {
+              ...boards_opts,
+              ...(boards_keysToInject.length > 0
+                ? { select: { ...boards_sel, ...Object.fromEntries(boards_keysToInject.map((k) => [k, true])) } }
+                : {}),
+              where: boards_perParentWhere,
+            },
+            { tx }
+          );
+          const stripped = children.map((c) => {
+            const _r = c as Record<string, unknown>;
+            return boards_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !boards_keysToInject.includes(k)))
+              : _r;
+          });
+          boards_hashMap!.set(JSON.stringify(parentId), stripped as unknown[]);
+        }
+      } else {
+        const boards_fkWhere = { userId: { in: boards_parentIds } };
+        const boards_where = boards_userWhere ? { AND: [boards_userWhere, boards_fkWhere] } : boards_fkWhere;
+        const boards_allRelated = await this.client.board.findMany(
+          {
+            ...boards_opts,
+            ...(boards_keysToInject.length > 0
+              ? { select: { ...boards_sel, ...Object.fromEntries(boards_keysToInject.map((k) => [k, true])) } }
+              : {}),
+            take: undefined,
+            skip: undefined,
+            where: boards_where,
+          },
+          { tx }
+        );
+        for (const related of boards_allRelated) {
+          const _r = related as Record<string, unknown>;
+          const key = JSON.stringify(_r["userId"]);
+          if (!boards_hashMap!.has(key)) boards_hashMap!.set(key, []);
+          const value =
+            boards_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !boards_keysToInject.includes(k)))
+              : _r;
+          boards_hashMap!.get(key)!.push(value as unknown);
+        }
+        if (boards_skip !== undefined || boards_take !== undefined) {
+          for (const [key, group] of boards_hashMap!) {
+            let sliced = group;
+            if (boards_skip !== undefined) sliced = sliced.slice(boards_skip);
+            if (boards_take !== undefined)
+              sliced = boards_take < 0 ? sliced.slice(boards_take) : sliced.slice(0, boards_take);
+            boards_hashMap!.set(key, sliced);
+          }
         }
       }
     }

--- a/apps/pidb-kanban-example/src/lib/prisma-idb/client/prisma-idb-client.ts
+++ b/apps/pidb-kanban-example/src/lib/prisma-idb/client/prisma-idb-client.ts
@@ -636,6 +636,8 @@ class BoardIDBClass extends BaseIDBModelClass<"Board"> {
   ): Promise<Prisma.Result<Prisma.BoardDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.BoardDelegate, Q, "findFirstOrThrow">[];
     const attach_todos = query.select?.todos || query.include?.todos;
+    const attach_user = query.select?.user || query.include?.user;
+    if (!attach_todos && !attach_user) return records as Prisma.Result<Prisma.BoardDelegate, Q, "findFirstOrThrow">[];
     let todos_hashMap: Map<string, unknown[]> | undefined;
     if (attach_todos) {
       const todos_opts = (attach_todos === true ? {} : attach_todos) as Record<string, unknown>;
@@ -711,7 +713,6 @@ class BoardIDBClass extends BaseIDBModelClass<"Board"> {
         }
       }
     }
-    const attach_user = query.select?.user || query.include?.user;
     let user_hashMap: Map<string, unknown> | undefined;
     if (attach_user) {
       const user_opts = (attach_user === true ? {} : attach_user) as Record<string, unknown>;
@@ -1815,6 +1816,7 @@ class TodoIDBClass extends BaseIDBModelClass<"Todo"> {
   ): Promise<Prisma.Result<Prisma.TodoDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.TodoDelegate, Q, "findFirstOrThrow">[];
     const attach_board = query.select?.board || query.include?.board;
+    if (!attach_board) return records as Prisma.Result<Prisma.TodoDelegate, Q, "findFirstOrThrow">[];
     let board_hashMap: Map<string, unknown> | undefined;
     if (attach_board) {
       const board_opts = (attach_board === true ? {} : attach_board) as Record<string, unknown>;
@@ -2702,6 +2704,7 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
   ): Promise<Prisma.Result<Prisma.UserDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.UserDelegate, Q, "findFirstOrThrow">[];
     const attach_boards = query.select?.boards || query.include?.boards;
+    if (!attach_boards) return records as Prisma.Result<Prisma.UserDelegate, Q, "findFirstOrThrow">[];
     let boards_hashMap: Map<string, unknown[]> | undefined;
     if (attach_boards) {
       const boards_opts = (attach_boards === true ? {} : attach_boards) as Record<string, unknown>;

--- a/apps/pidb-kanban-example/src/lib/prisma-idb/client/prisma-idb-client.ts
+++ b/apps/pidb-kanban-example/src/lib/prisma-idb/client/prisma-idb-client.ts
@@ -698,6 +698,9 @@ class BoardIDBClass extends BaseIDBModelClass<"Board"> {
           todos_hashMap!.get(key)!.push(value as unknown);
         }
         if (todos_skip !== undefined || todos_take !== undefined) {
+          if (todos_skip !== undefined && (!Number.isInteger(todos_skip) || todos_skip < 0))
+            throw new Error("skip must be a non-negative integer");
+          if (todos_take !== undefined && !Number.isInteger(todos_take)) throw new Error("take must be an integer");
           for (const [key, group] of todos_hashMap!) {
             let sliced = group;
             if (todos_skip !== undefined) sliced = sliced.slice(todos_skip);
@@ -743,10 +746,16 @@ class BoardIDBClass extends BaseIDBModelClass<"Board"> {
     const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
       if (attach_todos) {
-        unsafeRecord["todos"] = todos_hashMap!.get(JSON.stringify(record.id)) ?? [];
+        unsafeRecord["todos"] = (() => {
+          const _v = todos_hashMap!.get(JSON.stringify(record.id));
+          return _v == null ? [] : structuredClone(_v);
+        })();
       }
       if (attach_user) {
-        unsafeRecord["user"] = user_hashMap!.get(JSON.stringify(record.userId)) ?? null;
+        unsafeRecord["user"] = (() => {
+          const _v = user_hashMap!.get(JSON.stringify(record.userId));
+          return _v == null ? null : structuredClone(_v);
+        })();
       }
       return unsafeRecord;
     });
@@ -1840,7 +1849,10 @@ class TodoIDBClass extends BaseIDBModelClass<"Todo"> {
     const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
       if (attach_board) {
-        unsafeRecord["board"] = board_hashMap!.get(JSON.stringify(record.boardId)) ?? null;
+        unsafeRecord["board"] = (() => {
+          const _v = board_hashMap!.get(JSON.stringify(record.boardId));
+          return _v == null ? null : structuredClone(_v);
+        })();
       }
       return unsafeRecord;
     });
@@ -2752,6 +2764,9 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
           boards_hashMap!.get(key)!.push(value as unknown);
         }
         if (boards_skip !== undefined || boards_take !== undefined) {
+          if (boards_skip !== undefined && (!Number.isInteger(boards_skip) || boards_skip < 0))
+            throw new Error("skip must be a non-negative integer");
+          if (boards_take !== undefined && !Number.isInteger(boards_take)) throw new Error("take must be an integer");
           for (const [key, group] of boards_hashMap!) {
             let sliced = group;
             if (boards_skip !== undefined) sliced = sliced.slice(boards_skip);
@@ -2765,7 +2780,10 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
     const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
       if (attach_boards) {
-        unsafeRecord["boards"] = boards_hashMap!.get(JSON.stringify(record.id)) ?? [];
+        unsafeRecord["boards"] = (() => {
+          const _v = boards_hashMap!.get(JSON.stringify(record.id));
+          return _v == null ? [] : structuredClone(_v);
+        })();
       }
       return unsafeRecord;
     });

--- a/apps/pidb-kanban-example/src/lib/prisma-idb/client/prisma-idb-client.ts
+++ b/apps/pidb-kanban-example/src/lib/prisma-idb/client/prisma-idb-client.ts
@@ -635,31 +635,86 @@ class BoardIDBClass extends BaseIDBModelClass<"Board"> {
     query?: Q
   ): Promise<Prisma.Result<Prisma.BoardDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.BoardDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map(async (record) => {
-      const unsafeRecord = record as Record<string, unknown>;
-      const attach_todos = query.select?.todos || query.include?.todos;
-      if (attach_todos) {
-        unsafeRecord["todos"] = await this.client.todo.findMany(
-          {
-            ...(attach_todos === true ? {} : attach_todos),
-            where: { boardId: record.id! },
-          },
-          { tx }
-        );
+    const attach_todos = query.select?.todos || query.include?.todos;
+    let todos_hashMap: Map<string, unknown[]> | undefined;
+    if (attach_todos) {
+      const todos_opts = (attach_todos === true ? {} : attach_todos) as Record<string, unknown>;
+      const todos_sel = todos_opts.select as Record<string, boolean> | undefined;
+      const todos_keysToInject = todos_sel ? (["boardId"] as string[]).filter((k) => !todos_sel![k]) : [];
+      const todos_parentIds = [...new Set(records.map((r) => r.id))];
+      const todos_allRelated = await this.client.todo.findMany(
+        {
+          ...todos_opts,
+          ...(todos_keysToInject.length > 0
+            ? { select: { ...todos_sel, ...Object.fromEntries(todos_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          take: undefined,
+          skip: undefined,
+          where: { boardId: { in: todos_parentIds } },
+        },
+        { tx }
+      );
+      const todos_take = attach_todos !== true ? (attach_todos as Prisma.TodoFindManyArgs).take : undefined;
+      const todos_skip = attach_todos !== true ? (attach_todos as Prisma.TodoFindManyArgs).skip : undefined;
+      todos_hashMap = new Map<string, unknown[]>();
+      for (const related of todos_allRelated) {
+        const _r = related as Record<string, unknown>;
+        const key = JSON.stringify(_r["boardId"]);
+        if (!todos_hashMap!.has(key)) todos_hashMap!.set(key, []);
+        const value =
+          todos_keysToInject.length > 0
+            ? Object.fromEntries(Object.entries(_r).filter(([k]) => !todos_keysToInject.includes(k)))
+            : _r;
+        todos_hashMap!.get(key)!.push(value as unknown);
       }
-      const attach_user = query.select?.user || query.include?.user;
+      if (todos_skip !== undefined || todos_take !== undefined) {
+        for (const [key, group] of todos_hashMap!) {
+          const start = todos_skip ?? 0;
+          const end = todos_take !== undefined ? start + todos_take : undefined;
+          todos_hashMap!.set(key, group.slice(start, end));
+        }
+      }
+    }
+    const attach_user = query.select?.user || query.include?.user;
+    let user_hashMap: Map<string, unknown> | undefined;
+    if (attach_user) {
+      const user_opts = (attach_user === true ? {} : attach_user) as Record<string, unknown>;
+      const user_sel = user_opts.select as Record<string, boolean> | undefined;
+      const user_keysToInject = user_sel ? (["id"] as string[]).filter((k) => !user_sel![k]) : [];
+      const user_fkValues = [...new Set(records.map((r) => r.userId).filter((v) => v !== null && v !== undefined))];
+      const user_related = await this.client.user.findMany(
+        {
+          ...user_opts,
+          ...(user_keysToInject.length > 0
+            ? { select: { ...user_sel, ...Object.fromEntries(user_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          where: { id: { in: user_fkValues } },
+        },
+        { tx }
+      );
+      user_hashMap = new Map(
+        user_related.map((r) => {
+          const _r = r as Record<string, unknown>;
+          const key = JSON.stringify(_r["id"]);
+          const value =
+            user_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !user_keysToInject.includes(k)))
+              : _r;
+          return [key, value as unknown];
+        })
+      );
+    }
+    const recordsWithRelations = records.map((record) => {
+      const unsafeRecord = record as Record<string, unknown>;
+      if (attach_todos) {
+        unsafeRecord["todos"] = todos_hashMap!.get(JSON.stringify(record.id)) ?? [];
+      }
       if (attach_user) {
-        unsafeRecord["user"] = await this.client.user.findUnique(
-          {
-            ...(attach_user === true ? {} : attach_user),
-            where: { id: record.userId! },
-          },
-          { tx }
-        );
+        unsafeRecord["user"] = user_hashMap!.get(JSON.stringify(record.userId)) ?? null;
       }
       return unsafeRecord;
     });
-    return (await Promise.all(recordsWithRelations)) as Prisma.Result<Prisma.BoardDelegate, Q, "findFirstOrThrow">[];
+    return recordsWithRelations as Prisma.Result<Prisma.BoardDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.BoardDelegate, "findMany">["orderBy"],
@@ -1714,21 +1769,43 @@ class TodoIDBClass extends BaseIDBModelClass<"Todo"> {
     query?: Q
   ): Promise<Prisma.Result<Prisma.TodoDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.TodoDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map(async (record) => {
+    const attach_board = query.select?.board || query.include?.board;
+    let board_hashMap: Map<string, unknown> | undefined;
+    if (attach_board) {
+      const board_opts = (attach_board === true ? {} : attach_board) as Record<string, unknown>;
+      const board_sel = board_opts.select as Record<string, boolean> | undefined;
+      const board_keysToInject = board_sel ? (["id"] as string[]).filter((k) => !board_sel![k]) : [];
+      const board_fkValues = [...new Set(records.map((r) => r.boardId).filter((v) => v !== null && v !== undefined))];
+      const board_related = await this.client.board.findMany(
+        {
+          ...board_opts,
+          ...(board_keysToInject.length > 0
+            ? { select: { ...board_sel, ...Object.fromEntries(board_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          where: { id: { in: board_fkValues } },
+        },
+        { tx }
+      );
+      board_hashMap = new Map(
+        board_related.map((r) => {
+          const _r = r as Record<string, unknown>;
+          const key = JSON.stringify(_r["id"]);
+          const value =
+            board_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !board_keysToInject.includes(k)))
+              : _r;
+          return [key, value as unknown];
+        })
+      );
+    }
+    const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
-      const attach_board = query.select?.board || query.include?.board;
       if (attach_board) {
-        unsafeRecord["board"] = await this.client.board.findUnique(
-          {
-            ...(attach_board === true ? {} : attach_board),
-            where: { id: record.boardId! },
-          },
-          { tx }
-        );
+        unsafeRecord["board"] = board_hashMap!.get(JSON.stringify(record.boardId)) ?? null;
       }
       return unsafeRecord;
     });
-    return (await Promise.all(recordsWithRelations)) as Prisma.Result<Prisma.TodoDelegate, Q, "findFirstOrThrow">[];
+    return recordsWithRelations as Prisma.Result<Prisma.TodoDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.TodoDelegate, "findMany">["orderBy"],
@@ -2573,21 +2650,54 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
     query?: Q
   ): Promise<Prisma.Result<Prisma.UserDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.UserDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map(async (record) => {
+    const attach_boards = query.select?.boards || query.include?.boards;
+    let boards_hashMap: Map<string, unknown[]> | undefined;
+    if (attach_boards) {
+      const boards_opts = (attach_boards === true ? {} : attach_boards) as Record<string, unknown>;
+      const boards_sel = boards_opts.select as Record<string, boolean> | undefined;
+      const boards_keysToInject = boards_sel ? (["userId"] as string[]).filter((k) => !boards_sel![k]) : [];
+      const boards_parentIds = [...new Set(records.map((r) => r.id))];
+      const boards_allRelated = await this.client.board.findMany(
+        {
+          ...boards_opts,
+          ...(boards_keysToInject.length > 0
+            ? { select: { ...boards_sel, ...Object.fromEntries(boards_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          take: undefined,
+          skip: undefined,
+          where: { userId: { in: boards_parentIds } },
+        },
+        { tx }
+      );
+      const boards_take = attach_boards !== true ? (attach_boards as Prisma.BoardFindManyArgs).take : undefined;
+      const boards_skip = attach_boards !== true ? (attach_boards as Prisma.BoardFindManyArgs).skip : undefined;
+      boards_hashMap = new Map<string, unknown[]>();
+      for (const related of boards_allRelated) {
+        const _r = related as Record<string, unknown>;
+        const key = JSON.stringify(_r["userId"]);
+        if (!boards_hashMap!.has(key)) boards_hashMap!.set(key, []);
+        const value =
+          boards_keysToInject.length > 0
+            ? Object.fromEntries(Object.entries(_r).filter(([k]) => !boards_keysToInject.includes(k)))
+            : _r;
+        boards_hashMap!.get(key)!.push(value as unknown);
+      }
+      if (boards_skip !== undefined || boards_take !== undefined) {
+        for (const [key, group] of boards_hashMap!) {
+          const start = boards_skip ?? 0;
+          const end = boards_take !== undefined ? start + boards_take : undefined;
+          boards_hashMap!.set(key, group.slice(start, end));
+        }
+      }
+    }
+    const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
-      const attach_boards = query.select?.boards || query.include?.boards;
       if (attach_boards) {
-        unsafeRecord["boards"] = await this.client.board.findMany(
-          {
-            ...(attach_boards === true ? {} : attach_boards),
-            where: { userId: record.id! },
-          },
-          { tx }
-        );
+        unsafeRecord["boards"] = boards_hashMap!.get(JSON.stringify(record.id)) ?? [];
       }
       return unsafeRecord;
     });
-    return (await Promise.all(recordsWithRelations)) as Prisma.Result<Prisma.UserDelegate, Q, "findFirstOrThrow">[];
+    return recordsWithRelations as Prisma.Result<Prisma.UserDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.UserDelegate, "findMany">["orderBy"],

--- a/apps/usage/src/lib/prisma-idb/client/prisma-idb-client.ts
+++ b/apps/usage/src/lib/prisma-idb/client/prisma-idb-client.ts
@@ -533,91 +533,344 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
     query?: Q
   ): Promise<Prisma.Result<Prisma.UserDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.UserDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map(async (record) => {
+    const attach_profile = query.select?.profile || query.include?.profile;
+    let profile_hashMap: Map<string, unknown> | undefined;
+    if (attach_profile) {
+      const profile_opts = (attach_profile === true ? {} : attach_profile) as Record<string, unknown>;
+      const profile_sel = profile_opts.select as Record<string, boolean> | undefined;
+      const profile_keysToInject = profile_sel ? (["userId"] as string[]).filter((k) => !profile_sel![k]) : [];
+      const profile_parentIds = [...new Set(records.map((r) => r.id))];
+      const profile_related = await this.client.profile.findMany(
+        {
+          ...profile_opts,
+          ...(profile_keysToInject.length > 0
+            ? { select: { ...profile_sel, ...Object.fromEntries(profile_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          where: { userId: { in: profile_parentIds } },
+        },
+        { tx }
+      );
+      profile_hashMap = new Map(
+        profile_related.map((r) => {
+          const _r = r as Record<string, unknown>;
+          const key = JSON.stringify(_r["userId"]);
+          const value =
+            profile_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !profile_keysToInject.includes(k)))
+              : _r;
+          return [key, value as unknown];
+        })
+      );
+    }
+    const attach_posts = query.select?.posts || query.include?.posts;
+    let posts_hashMap: Map<string, unknown[]> | undefined;
+    if (attach_posts) {
+      const posts_opts = (attach_posts === true ? {} : attach_posts) as Record<string, unknown>;
+      const posts_sel = posts_opts.select as Record<string, boolean> | undefined;
+      const posts_keysToInject = posts_sel ? (["authorId"] as string[]).filter((k) => !posts_sel![k]) : [];
+      const posts_parentIds = [...new Set(records.map((r) => r.id))];
+      const posts_allRelated = await this.client.post.findMany(
+        {
+          ...posts_opts,
+          ...(posts_keysToInject.length > 0
+            ? { select: { ...posts_sel, ...Object.fromEntries(posts_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          take: undefined,
+          skip: undefined,
+          where: { authorId: { in: posts_parentIds } },
+        },
+        { tx }
+      );
+      const posts_take = attach_posts !== true ? (attach_posts as Prisma.PostFindManyArgs).take : undefined;
+      const posts_skip = attach_posts !== true ? (attach_posts as Prisma.PostFindManyArgs).skip : undefined;
+      posts_hashMap = new Map<string, unknown[]>();
+      for (const related of posts_allRelated) {
+        const _r = related as Record<string, unknown>;
+        const key = JSON.stringify(_r["authorId"]);
+        if (!posts_hashMap!.has(key)) posts_hashMap!.set(key, []);
+        const value =
+          posts_keysToInject.length > 0
+            ? Object.fromEntries(Object.entries(_r).filter(([k]) => !posts_keysToInject.includes(k)))
+            : _r;
+        posts_hashMap!.get(key)!.push(value as unknown);
+      }
+      if (posts_skip !== undefined || posts_take !== undefined) {
+        for (const [key, group] of posts_hashMap!) {
+          const start = posts_skip ?? 0;
+          const end = posts_take !== undefined ? start + posts_take : undefined;
+          posts_hashMap!.set(key, group.slice(start, end));
+        }
+      }
+    }
+    const attach_comments = query.select?.comments || query.include?.comments;
+    let comments_hashMap: Map<string, unknown[]> | undefined;
+    if (attach_comments) {
+      const comments_opts = (attach_comments === true ? {} : attach_comments) as Record<string, unknown>;
+      const comments_sel = comments_opts.select as Record<string, boolean> | undefined;
+      const comments_keysToInject = comments_sel ? (["userId"] as string[]).filter((k) => !comments_sel![k]) : [];
+      const comments_parentIds = [...new Set(records.map((r) => r.id))];
+      const comments_allRelated = await this.client.comment.findMany(
+        {
+          ...comments_opts,
+          ...(comments_keysToInject.length > 0
+            ? { select: { ...comments_sel, ...Object.fromEntries(comments_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          take: undefined,
+          skip: undefined,
+          where: { userId: { in: comments_parentIds } },
+        },
+        { tx }
+      );
+      const comments_take = attach_comments !== true ? (attach_comments as Prisma.CommentFindManyArgs).take : undefined;
+      const comments_skip = attach_comments !== true ? (attach_comments as Prisma.CommentFindManyArgs).skip : undefined;
+      comments_hashMap = new Map<string, unknown[]>();
+      for (const related of comments_allRelated) {
+        const _r = related as Record<string, unknown>;
+        const key = JSON.stringify(_r["userId"]);
+        if (!comments_hashMap!.has(key)) comments_hashMap!.set(key, []);
+        const value =
+          comments_keysToInject.length > 0
+            ? Object.fromEntries(Object.entries(_r).filter(([k]) => !comments_keysToInject.includes(k)))
+            : _r;
+        comments_hashMap!.get(key)!.push(value as unknown);
+      }
+      if (comments_skip !== undefined || comments_take !== undefined) {
+        for (const [key, group] of comments_hashMap!) {
+          const start = comments_skip ?? 0;
+          const end = comments_take !== undefined ? start + comments_take : undefined;
+          comments_hashMap!.set(key, group.slice(start, end));
+        }
+      }
+    }
+    const attach_Child = query.select?.Child || query.include?.Child;
+    let Child_hashMap: Map<string, unknown[]> | undefined;
+    if (attach_Child) {
+      const Child_opts = (attach_Child === true ? {} : attach_Child) as Record<string, unknown>;
+      const Child_sel = Child_opts.select as Record<string, boolean> | undefined;
+      const Child_keysToInject = Child_sel ? (["userId"] as string[]).filter((k) => !Child_sel![k]) : [];
+      const Child_parentIds = [...new Set(records.map((r) => r.id))];
+      const Child_allRelated = await this.client.child.findMany(
+        {
+          ...Child_opts,
+          ...(Child_keysToInject.length > 0
+            ? { select: { ...Child_sel, ...Object.fromEntries(Child_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          take: undefined,
+          skip: undefined,
+          where: { userId: { in: Child_parentIds } },
+        },
+        { tx }
+      );
+      const Child_take = attach_Child !== true ? (attach_Child as Prisma.ChildFindManyArgs).take : undefined;
+      const Child_skip = attach_Child !== true ? (attach_Child as Prisma.ChildFindManyArgs).skip : undefined;
+      Child_hashMap = new Map<string, unknown[]>();
+      for (const related of Child_allRelated) {
+        const _r = related as Record<string, unknown>;
+        const key = JSON.stringify(_r["userId"]);
+        if (!Child_hashMap!.has(key)) Child_hashMap!.set(key, []);
+        const value =
+          Child_keysToInject.length > 0
+            ? Object.fromEntries(Object.entries(_r).filter(([k]) => !Child_keysToInject.includes(k)))
+            : _r;
+        Child_hashMap!.get(key)!.push(value as unknown);
+      }
+      if (Child_skip !== undefined || Child_take !== undefined) {
+        for (const [key, group] of Child_hashMap!) {
+          const start = Child_skip ?? 0;
+          const end = Child_take !== undefined ? start + Child_take : undefined;
+          Child_hashMap!.set(key, group.slice(start, end));
+        }
+      }
+    }
+    const attach_Father = query.select?.Father || query.include?.Father;
+    let Father_hashMap: Map<string, unknown[]> | undefined;
+    if (attach_Father) {
+      const Father_opts = (attach_Father === true ? {} : attach_Father) as Record<string, unknown>;
+      const Father_sel = Father_opts.select as Record<string, boolean> | undefined;
+      const Father_keysToInject = Father_sel ? (["userId"] as string[]).filter((k) => !Father_sel![k]) : [];
+      const Father_parentIds = [...new Set(records.map((r) => r.id))];
+      const Father_allRelated = await this.client.father.findMany(
+        {
+          ...Father_opts,
+          ...(Father_keysToInject.length > 0
+            ? { select: { ...Father_sel, ...Object.fromEntries(Father_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          take: undefined,
+          skip: undefined,
+          where: { userId: { in: Father_parentIds } },
+        },
+        { tx }
+      );
+      const Father_take = attach_Father !== true ? (attach_Father as Prisma.FatherFindManyArgs).take : undefined;
+      const Father_skip = attach_Father !== true ? (attach_Father as Prisma.FatherFindManyArgs).skip : undefined;
+      Father_hashMap = new Map<string, unknown[]>();
+      for (const related of Father_allRelated) {
+        const _r = related as Record<string, unknown>;
+        const key = JSON.stringify(_r["userId"]);
+        if (!Father_hashMap!.has(key)) Father_hashMap!.set(key, []);
+        const value =
+          Father_keysToInject.length > 0
+            ? Object.fromEntries(Object.entries(_r).filter(([k]) => !Father_keysToInject.includes(k)))
+            : _r;
+        Father_hashMap!.get(key)!.push(value as unknown);
+      }
+      if (Father_skip !== undefined || Father_take !== undefined) {
+        for (const [key, group] of Father_hashMap!) {
+          const start = Father_skip ?? 0;
+          const end = Father_take !== undefined ? start + Father_take : undefined;
+          Father_hashMap!.set(key, group.slice(start, end));
+        }
+      }
+    }
+    const attach_Mother = query.select?.Mother || query.include?.Mother;
+    let Mother_hashMap: Map<string, unknown[]> | undefined;
+    if (attach_Mother) {
+      const Mother_opts = (attach_Mother === true ? {} : attach_Mother) as Record<string, unknown>;
+      const Mother_sel = Mother_opts.select as Record<string, boolean> | undefined;
+      const Mother_keysToInject = Mother_sel ? (["userId"] as string[]).filter((k) => !Mother_sel![k]) : [];
+      const Mother_parentIds = [...new Set(records.map((r) => r.id))];
+      const Mother_allRelated = await this.client.mother.findMany(
+        {
+          ...Mother_opts,
+          ...(Mother_keysToInject.length > 0
+            ? { select: { ...Mother_sel, ...Object.fromEntries(Mother_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          take: undefined,
+          skip: undefined,
+          where: { userId: { in: Mother_parentIds } },
+        },
+        { tx }
+      );
+      const Mother_take = attach_Mother !== true ? (attach_Mother as Prisma.MotherFindManyArgs).take : undefined;
+      const Mother_skip = attach_Mother !== true ? (attach_Mother as Prisma.MotherFindManyArgs).skip : undefined;
+      Mother_hashMap = new Map<string, unknown[]>();
+      for (const related of Mother_allRelated) {
+        const _r = related as Record<string, unknown>;
+        const key = JSON.stringify(_r["userId"]);
+        if (!Mother_hashMap!.has(key)) Mother_hashMap!.set(key, []);
+        const value =
+          Mother_keysToInject.length > 0
+            ? Object.fromEntries(Object.entries(_r).filter(([k]) => !Mother_keysToInject.includes(k)))
+            : _r;
+        Mother_hashMap!.get(key)!.push(value as unknown);
+      }
+      if (Mother_skip !== undefined || Mother_take !== undefined) {
+        for (const [key, group] of Mother_hashMap!) {
+          const start = Mother_skip ?? 0;
+          const end = Mother_take !== undefined ? start + Mother_take : undefined;
+          Mother_hashMap!.set(key, group.slice(start, end));
+        }
+      }
+    }
+    const attach_groups = query.select?.groups || query.include?.groups;
+    let groups_hashMap: Map<string, unknown[]> | undefined;
+    if (attach_groups) {
+      const groups_opts = (attach_groups === true ? {} : attach_groups) as Record<string, unknown>;
+      const groups_sel = groups_opts.select as Record<string, boolean> | undefined;
+      const groups_keysToInject = groups_sel ? (["userId"] as string[]).filter((k) => !groups_sel![k]) : [];
+      const groups_parentIds = [...new Set(records.map((r) => r.id))];
+      const groups_allRelated = await this.client.userGroup.findMany(
+        {
+          ...groups_opts,
+          ...(groups_keysToInject.length > 0
+            ? { select: { ...groups_sel, ...Object.fromEntries(groups_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          take: undefined,
+          skip: undefined,
+          where: { userId: { in: groups_parentIds } },
+        },
+        { tx }
+      );
+      const groups_take = attach_groups !== true ? (attach_groups as Prisma.UserGroupFindManyArgs).take : undefined;
+      const groups_skip = attach_groups !== true ? (attach_groups as Prisma.UserGroupFindManyArgs).skip : undefined;
+      groups_hashMap = new Map<string, unknown[]>();
+      for (const related of groups_allRelated) {
+        const _r = related as Record<string, unknown>;
+        const key = JSON.stringify(_r["userId"]);
+        if (!groups_hashMap!.has(key)) groups_hashMap!.set(key, []);
+        const value =
+          groups_keysToInject.length > 0
+            ? Object.fromEntries(Object.entries(_r).filter(([k]) => !groups_keysToInject.includes(k)))
+            : _r;
+        groups_hashMap!.get(key)!.push(value as unknown);
+      }
+      if (groups_skip !== undefined || groups_take !== undefined) {
+        for (const [key, group] of groups_hashMap!) {
+          const start = groups_skip ?? 0;
+          const end = groups_take !== undefined ? start + groups_take : undefined;
+          groups_hashMap!.set(key, group.slice(start, end));
+        }
+      }
+    }
+    const attach_todos = query.select?.todos || query.include?.todos;
+    let todos_hashMap: Map<string, unknown[]> | undefined;
+    if (attach_todos) {
+      const todos_opts = (attach_todos === true ? {} : attach_todos) as Record<string, unknown>;
+      const todos_sel = todos_opts.select as Record<string, boolean> | undefined;
+      const todos_keysToInject = todos_sel ? (["userId"] as string[]).filter((k) => !todos_sel![k]) : [];
+      const todos_parentIds = [...new Set(records.map((r) => r.id))];
+      const todos_allRelated = await this.client.todo.findMany(
+        {
+          ...todos_opts,
+          ...(todos_keysToInject.length > 0
+            ? { select: { ...todos_sel, ...Object.fromEntries(todos_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          take: undefined,
+          skip: undefined,
+          where: { userId: { in: todos_parentIds } },
+        },
+        { tx }
+      );
+      const todos_take = attach_todos !== true ? (attach_todos as Prisma.TodoFindManyArgs).take : undefined;
+      const todos_skip = attach_todos !== true ? (attach_todos as Prisma.TodoFindManyArgs).skip : undefined;
+      todos_hashMap = new Map<string, unknown[]>();
+      for (const related of todos_allRelated) {
+        const _r = related as Record<string, unknown>;
+        const key = JSON.stringify(_r["userId"]);
+        if (!todos_hashMap!.has(key)) todos_hashMap!.set(key, []);
+        const value =
+          todos_keysToInject.length > 0
+            ? Object.fromEntries(Object.entries(_r).filter(([k]) => !todos_keysToInject.includes(k)))
+            : _r;
+        todos_hashMap!.get(key)!.push(value as unknown);
+      }
+      if (todos_skip !== undefined || todos_take !== undefined) {
+        for (const [key, group] of todos_hashMap!) {
+          const start = todos_skip ?? 0;
+          const end = todos_take !== undefined ? start + todos_take : undefined;
+          todos_hashMap!.set(key, group.slice(start, end));
+        }
+      }
+    }
+    const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
-      const attach_profile = query.select?.profile || query.include?.profile;
       if (attach_profile) {
-        unsafeRecord["profile"] = await this.client.profile.findUnique(
-          {
-            ...(attach_profile === true ? {} : attach_profile),
-            where: { userId: record.id },
-          },
-          { tx }
-        );
+        unsafeRecord["profile"] = profile_hashMap!.get(JSON.stringify(record.id)) ?? null;
       }
-      const attach_posts = query.select?.posts || query.include?.posts;
       if (attach_posts) {
-        unsafeRecord["posts"] = await this.client.post.findMany(
-          {
-            ...(attach_posts === true ? {} : attach_posts),
-            where: { authorId: record.id! },
-          },
-          { tx }
-        );
+        unsafeRecord["posts"] = posts_hashMap!.get(JSON.stringify(record.id)) ?? [];
       }
-      const attach_comments = query.select?.comments || query.include?.comments;
       if (attach_comments) {
-        unsafeRecord["comments"] = await this.client.comment.findMany(
-          {
-            ...(attach_comments === true ? {} : attach_comments),
-            where: { userId: record.id! },
-          },
-          { tx }
-        );
+        unsafeRecord["comments"] = comments_hashMap!.get(JSON.stringify(record.id)) ?? [];
       }
-      const attach_Child = query.select?.Child || query.include?.Child;
       if (attach_Child) {
-        unsafeRecord["Child"] = await this.client.child.findMany(
-          {
-            ...(attach_Child === true ? {} : attach_Child),
-            where: { userId: record.id! },
-          },
-          { tx }
-        );
+        unsafeRecord["Child"] = Child_hashMap!.get(JSON.stringify(record.id)) ?? [];
       }
-      const attach_Father = query.select?.Father || query.include?.Father;
       if (attach_Father) {
-        unsafeRecord["Father"] = await this.client.father.findMany(
-          {
-            ...(attach_Father === true ? {} : attach_Father),
-            where: { userId: record.id! },
-          },
-          { tx }
-        );
+        unsafeRecord["Father"] = Father_hashMap!.get(JSON.stringify(record.id)) ?? [];
       }
-      const attach_Mother = query.select?.Mother || query.include?.Mother;
       if (attach_Mother) {
-        unsafeRecord["Mother"] = await this.client.mother.findMany(
-          {
-            ...(attach_Mother === true ? {} : attach_Mother),
-            where: { userId: record.id! },
-          },
-          { tx }
-        );
+        unsafeRecord["Mother"] = Mother_hashMap!.get(JSON.stringify(record.id)) ?? [];
       }
-      const attach_groups = query.select?.groups || query.include?.groups;
       if (attach_groups) {
-        unsafeRecord["groups"] = await this.client.userGroup.findMany(
-          {
-            ...(attach_groups === true ? {} : attach_groups),
-            where: { userId: record.id! },
-          },
-          { tx }
-        );
+        unsafeRecord["groups"] = groups_hashMap!.get(JSON.stringify(record.id)) ?? [];
       }
-      const attach_todos = query.select?.todos || query.include?.todos;
       if (attach_todos) {
-        unsafeRecord["todos"] = await this.client.todo.findMany(
-          {
-            ...(attach_todos === true ? {} : attach_todos),
-            where: { userId: record.id! },
-          },
-          { tx }
-        );
+        unsafeRecord["todos"] = todos_hashMap!.get(JSON.stringify(record.id)) ?? [];
       }
       return unsafeRecord;
     });
-    return (await Promise.all(recordsWithRelations)) as Prisma.Result<Prisma.UserDelegate, Q, "findFirstOrThrow">[];
+    return recordsWithRelations as Prisma.Result<Prisma.UserDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.UserDelegate, "findMany">["orderBy"],
@@ -3284,21 +3537,58 @@ class GroupIDBClass extends BaseIDBModelClass<"Group"> {
     query?: Q
   ): Promise<Prisma.Result<Prisma.GroupDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.GroupDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map(async (record) => {
+    const attach_userGroups = query.select?.userGroups || query.include?.userGroups;
+    let userGroups_hashMap: Map<string, unknown[]> | undefined;
+    if (attach_userGroups) {
+      const userGroups_opts = (attach_userGroups === true ? {} : attach_userGroups) as Record<string, unknown>;
+      const userGroups_sel = userGroups_opts.select as Record<string, boolean> | undefined;
+      const userGroups_keysToInject = userGroups_sel
+        ? (["groupId"] as string[]).filter((k) => !userGroups_sel![k])
+        : [];
+      const userGroups_parentIds = [...new Set(records.map((r) => r.id))];
+      const userGroups_allRelated = await this.client.userGroup.findMany(
+        {
+          ...userGroups_opts,
+          ...(userGroups_keysToInject.length > 0
+            ? { select: { ...userGroups_sel, ...Object.fromEntries(userGroups_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          take: undefined,
+          skip: undefined,
+          where: { groupId: { in: userGroups_parentIds } },
+        },
+        { tx }
+      );
+      const userGroups_take =
+        attach_userGroups !== true ? (attach_userGroups as Prisma.UserGroupFindManyArgs).take : undefined;
+      const userGroups_skip =
+        attach_userGroups !== true ? (attach_userGroups as Prisma.UserGroupFindManyArgs).skip : undefined;
+      userGroups_hashMap = new Map<string, unknown[]>();
+      for (const related of userGroups_allRelated) {
+        const _r = related as Record<string, unknown>;
+        const key = JSON.stringify(_r["groupId"]);
+        if (!userGroups_hashMap!.has(key)) userGroups_hashMap!.set(key, []);
+        const value =
+          userGroups_keysToInject.length > 0
+            ? Object.fromEntries(Object.entries(_r).filter(([k]) => !userGroups_keysToInject.includes(k)))
+            : _r;
+        userGroups_hashMap!.get(key)!.push(value as unknown);
+      }
+      if (userGroups_skip !== undefined || userGroups_take !== undefined) {
+        for (const [key, group] of userGroups_hashMap!) {
+          const start = userGroups_skip ?? 0;
+          const end = userGroups_take !== undefined ? start + userGroups_take : undefined;
+          userGroups_hashMap!.set(key, group.slice(start, end));
+        }
+      }
+    }
+    const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
-      const attach_userGroups = query.select?.userGroups || query.include?.userGroups;
       if (attach_userGroups) {
-        unsafeRecord["userGroups"] = await this.client.userGroup.findMany(
-          {
-            ...(attach_userGroups === true ? {} : attach_userGroups),
-            where: { groupId: record.id! },
-          },
-          { tx }
-        );
+        unsafeRecord["userGroups"] = userGroups_hashMap!.get(JSON.stringify(record.id)) ?? [];
       }
       return unsafeRecord;
     });
-    return (await Promise.all(recordsWithRelations)) as Prisma.Result<Prisma.GroupDelegate, Q, "findFirstOrThrow">[];
+    return recordsWithRelations as Prisma.Result<Prisma.GroupDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.GroupDelegate, "findMany">["orderBy"],
@@ -4184,21 +4474,43 @@ class ProfileIDBClass extends BaseIDBModelClass<"Profile"> {
     query?: Q
   ): Promise<Prisma.Result<Prisma.ProfileDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.ProfileDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map(async (record) => {
+    const attach_user = query.select?.user || query.include?.user;
+    let user_hashMap: Map<string, unknown> | undefined;
+    if (attach_user) {
+      const user_opts = (attach_user === true ? {} : attach_user) as Record<string, unknown>;
+      const user_sel = user_opts.select as Record<string, boolean> | undefined;
+      const user_keysToInject = user_sel ? (["id"] as string[]).filter((k) => !user_sel![k]) : [];
+      const user_fkValues = [...new Set(records.map((r) => r.userId).filter((v) => v !== null && v !== undefined))];
+      const user_related = await this.client.user.findMany(
+        {
+          ...user_opts,
+          ...(user_keysToInject.length > 0
+            ? { select: { ...user_sel, ...Object.fromEntries(user_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          where: { id: { in: user_fkValues } },
+        },
+        { tx }
+      );
+      user_hashMap = new Map(
+        user_related.map((r) => {
+          const _r = r as Record<string, unknown>;
+          const key = JSON.stringify(_r["id"]);
+          const value =
+            user_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !user_keysToInject.includes(k)))
+              : _r;
+          return [key, value as unknown];
+        })
+      );
+    }
+    const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
-      const attach_user = query.select?.user || query.include?.user;
       if (attach_user) {
-        unsafeRecord["user"] = await this.client.user.findUnique(
-          {
-            ...(attach_user === true ? {} : attach_user),
-            where: { id: record.userId! },
-          },
-          { tx }
-        );
+        unsafeRecord["user"] = user_hashMap!.get(JSON.stringify(record.userId)) ?? null;
       }
       return unsafeRecord;
     });
-    return (await Promise.all(recordsWithRelations)) as Prisma.Result<Prisma.ProfileDelegate, Q, "findFirstOrThrow">[];
+    return recordsWithRelations as Prisma.Result<Prisma.ProfileDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.ProfileDelegate, "findMany">["orderBy"],
@@ -5048,34 +5360,87 @@ class PostIDBClass extends BaseIDBModelClass<"Post"> {
     query?: Q
   ): Promise<Prisma.Result<Prisma.PostDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.PostDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map(async (record) => {
+    const attach_author = query.select?.author || query.include?.author;
+    let author_hashMap: Map<string, unknown> | undefined;
+    if (attach_author) {
+      const author_opts = (attach_author === true ? {} : attach_author) as Record<string, unknown>;
+      const author_sel = author_opts.select as Record<string, boolean> | undefined;
+      const author_keysToInject = author_sel ? (["id"] as string[]).filter((k) => !author_sel![k]) : [];
+      const author_fkValues = [...new Set(records.map((r) => r.authorId).filter((v) => v !== null && v !== undefined))];
+      const author_related = await this.client.user.findMany(
+        {
+          ...author_opts,
+          ...(author_keysToInject.length > 0
+            ? { select: { ...author_sel, ...Object.fromEntries(author_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          where: { id: { in: author_fkValues } },
+        },
+        { tx }
+      );
+      author_hashMap = new Map(
+        author_related.map((r) => {
+          const _r = r as Record<string, unknown>;
+          const key = JSON.stringify(_r["id"]);
+          const value =
+            author_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !author_keysToInject.includes(k)))
+              : _r;
+          return [key, value as unknown];
+        })
+      );
+    }
+    const attach_comments = query.select?.comments || query.include?.comments;
+    let comments_hashMap: Map<string, unknown[]> | undefined;
+    if (attach_comments) {
+      const comments_opts = (attach_comments === true ? {} : attach_comments) as Record<string, unknown>;
+      const comments_sel = comments_opts.select as Record<string, boolean> | undefined;
+      const comments_keysToInject = comments_sel ? (["postId"] as string[]).filter((k) => !comments_sel![k]) : [];
+      const comments_parentIds = [...new Set(records.map((r) => r.id))];
+      const comments_allRelated = await this.client.comment.findMany(
+        {
+          ...comments_opts,
+          ...(comments_keysToInject.length > 0
+            ? { select: { ...comments_sel, ...Object.fromEntries(comments_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          take: undefined,
+          skip: undefined,
+          where: { postId: { in: comments_parentIds } },
+        },
+        { tx }
+      );
+      const comments_take = attach_comments !== true ? (attach_comments as Prisma.CommentFindManyArgs).take : undefined;
+      const comments_skip = attach_comments !== true ? (attach_comments as Prisma.CommentFindManyArgs).skip : undefined;
+      comments_hashMap = new Map<string, unknown[]>();
+      for (const related of comments_allRelated) {
+        const _r = related as Record<string, unknown>;
+        const key = JSON.stringify(_r["postId"]);
+        if (!comments_hashMap!.has(key)) comments_hashMap!.set(key, []);
+        const value =
+          comments_keysToInject.length > 0
+            ? Object.fromEntries(Object.entries(_r).filter(([k]) => !comments_keysToInject.includes(k)))
+            : _r;
+        comments_hashMap!.get(key)!.push(value as unknown);
+      }
+      if (comments_skip !== undefined || comments_take !== undefined) {
+        for (const [key, group] of comments_hashMap!) {
+          const start = comments_skip ?? 0;
+          const end = comments_take !== undefined ? start + comments_take : undefined;
+          comments_hashMap!.set(key, group.slice(start, end));
+        }
+      }
+    }
+    const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
-      const attach_author = query.select?.author || query.include?.author;
       if (attach_author) {
         unsafeRecord["author"] =
-          record.authorId === null
-            ? null
-            : await this.client.user.findUnique(
-                {
-                  ...(attach_author === true ? {} : attach_author),
-                  where: { id: record.authorId! },
-                },
-                { tx }
-              );
+          record.authorId === null ? null : (author_hashMap!.get(JSON.stringify(record.authorId)) ?? null);
       }
-      const attach_comments = query.select?.comments || query.include?.comments;
       if (attach_comments) {
-        unsafeRecord["comments"] = await this.client.comment.findMany(
-          {
-            ...(attach_comments === true ? {} : attach_comments),
-            where: { postId: record.id! },
-          },
-          { tx }
-        );
+        unsafeRecord["comments"] = comments_hashMap!.get(JSON.stringify(record.id)) ?? [];
       }
       return unsafeRecord;
     });
-    return (await Promise.all(recordsWithRelations)) as Prisma.Result<Prisma.PostDelegate, Q, "findFirstOrThrow">[];
+    return recordsWithRelations as Prisma.Result<Prisma.PostDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.PostDelegate, "findMany">["orderBy"],
@@ -6200,31 +6565,75 @@ class CommentIDBClass extends BaseIDBModelClass<"Comment"> {
     query?: Q
   ): Promise<Prisma.Result<Prisma.CommentDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.CommentDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map(async (record) => {
+    const attach_post = query.select?.post || query.include?.post;
+    let post_hashMap: Map<string, unknown> | undefined;
+    if (attach_post) {
+      const post_opts = (attach_post === true ? {} : attach_post) as Record<string, unknown>;
+      const post_sel = post_opts.select as Record<string, boolean> | undefined;
+      const post_keysToInject = post_sel ? (["id"] as string[]).filter((k) => !post_sel![k]) : [];
+      const post_fkValues = [...new Set(records.map((r) => r.postId).filter((v) => v !== null && v !== undefined))];
+      const post_related = await this.client.post.findMany(
+        {
+          ...post_opts,
+          ...(post_keysToInject.length > 0
+            ? { select: { ...post_sel, ...Object.fromEntries(post_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          where: { id: { in: post_fkValues } },
+        },
+        { tx }
+      );
+      post_hashMap = new Map(
+        post_related.map((r) => {
+          const _r = r as Record<string, unknown>;
+          const key = JSON.stringify(_r["id"]);
+          const value =
+            post_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !post_keysToInject.includes(k)))
+              : _r;
+          return [key, value as unknown];
+        })
+      );
+    }
+    const attach_user = query.select?.user || query.include?.user;
+    let user_hashMap: Map<string, unknown> | undefined;
+    if (attach_user) {
+      const user_opts = (attach_user === true ? {} : attach_user) as Record<string, unknown>;
+      const user_sel = user_opts.select as Record<string, boolean> | undefined;
+      const user_keysToInject = user_sel ? (["id"] as string[]).filter((k) => !user_sel![k]) : [];
+      const user_fkValues = [...new Set(records.map((r) => r.userId).filter((v) => v !== null && v !== undefined))];
+      const user_related = await this.client.user.findMany(
+        {
+          ...user_opts,
+          ...(user_keysToInject.length > 0
+            ? { select: { ...user_sel, ...Object.fromEntries(user_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          where: { id: { in: user_fkValues } },
+        },
+        { tx }
+      );
+      user_hashMap = new Map(
+        user_related.map((r) => {
+          const _r = r as Record<string, unknown>;
+          const key = JSON.stringify(_r["id"]);
+          const value =
+            user_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !user_keysToInject.includes(k)))
+              : _r;
+          return [key, value as unknown];
+        })
+      );
+    }
+    const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
-      const attach_post = query.select?.post || query.include?.post;
       if (attach_post) {
-        unsafeRecord["post"] = await this.client.post.findUnique(
-          {
-            ...(attach_post === true ? {} : attach_post),
-            where: { id: record.postId! },
-          },
-          { tx }
-        );
+        unsafeRecord["post"] = post_hashMap!.get(JSON.stringify(record.postId)) ?? null;
       }
-      const attach_user = query.select?.user || query.include?.user;
       if (attach_user) {
-        unsafeRecord["user"] = await this.client.user.findUnique(
-          {
-            ...(attach_user === true ? {} : attach_user),
-            where: { id: record.userId! },
-          },
-          { tx }
-        );
+        unsafeRecord["user"] = user_hashMap!.get(JSON.stringify(record.userId)) ?? null;
       }
       return unsafeRecord;
     });
-    return (await Promise.all(recordsWithRelations)) as Prisma.Result<Prisma.CommentDelegate, Q, "findFirstOrThrow">[];
+    return recordsWithRelations as Prisma.Result<Prisma.CommentDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.CommentDelegate, "findMany">["orderBy"],
@@ -7184,21 +7593,43 @@ class TodoIDBClass extends BaseIDBModelClass<"Todo"> {
     query?: Q
   ): Promise<Prisma.Result<Prisma.TodoDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.TodoDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map(async (record) => {
+    const attach_user = query.select?.user || query.include?.user;
+    let user_hashMap: Map<string, unknown> | undefined;
+    if (attach_user) {
+      const user_opts = (attach_user === true ? {} : attach_user) as Record<string, unknown>;
+      const user_sel = user_opts.select as Record<string, boolean> | undefined;
+      const user_keysToInject = user_sel ? (["id"] as string[]).filter((k) => !user_sel![k]) : [];
+      const user_fkValues = [...new Set(records.map((r) => r.userId).filter((v) => v !== null && v !== undefined))];
+      const user_related = await this.client.user.findMany(
+        {
+          ...user_opts,
+          ...(user_keysToInject.length > 0
+            ? { select: { ...user_sel, ...Object.fromEntries(user_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          where: { id: { in: user_fkValues } },
+        },
+        { tx }
+      );
+      user_hashMap = new Map(
+        user_related.map((r) => {
+          const _r = r as Record<string, unknown>;
+          const key = JSON.stringify(_r["id"]);
+          const value =
+            user_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !user_keysToInject.includes(k)))
+              : _r;
+          return [key, value as unknown];
+        })
+      );
+    }
+    const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
-      const attach_user = query.select?.user || query.include?.user;
       if (attach_user) {
-        unsafeRecord["user"] = await this.client.user.findUnique(
-          {
-            ...(attach_user === true ? {} : attach_user),
-            where: { id: record.userId! },
-          },
-          { tx }
-        );
+        unsafeRecord["user"] = user_hashMap!.get(JSON.stringify(record.userId)) ?? null;
       }
       return unsafeRecord;
     });
-    return (await Promise.all(recordsWithRelations)) as Prisma.Result<Prisma.TodoDelegate, Q, "findFirstOrThrow">[];
+    return recordsWithRelations as Prisma.Result<Prisma.TodoDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.TodoDelegate, "findMany">["orderBy"],
@@ -8040,15 +8471,11 @@ class AllFieldScalarTypesIDBClass extends BaseIDBModelClass<"AllFieldScalarTypes
     query?: Q
   ): Promise<Prisma.Result<Prisma.AllFieldScalarTypesDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.AllFieldScalarTypesDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map(async (record) => {
+    const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
       return unsafeRecord;
     });
-    return (await Promise.all(recordsWithRelations)) as Prisma.Result<
-      Prisma.AllFieldScalarTypesDelegate,
-      Q,
-      "findFirstOrThrow"
-    >[];
+    return recordsWithRelations as Prisma.Result<Prisma.AllFieldScalarTypesDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.AllFieldScalarTypesDelegate, "findMany">["orderBy"],
@@ -8778,15 +9205,11 @@ class ModelWithEnumIDBClass extends BaseIDBModelClass<"ModelWithEnum"> {
     query?: Q
   ): Promise<Prisma.Result<Prisma.ModelWithEnumDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.ModelWithEnumDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map(async (record) => {
+    const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
       return unsafeRecord;
     });
-    return (await Promise.all(recordsWithRelations)) as Prisma.Result<
-      Prisma.ModelWithEnumDelegate,
-      Q,
-      "findFirstOrThrow"
-    >[];
+    return recordsWithRelations as Prisma.Result<Prisma.ModelWithEnumDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.ModelWithEnumDelegate, "findMany">["orderBy"],
@@ -9387,11 +9810,11 @@ class TestUuidIDBClass extends BaseIDBModelClass<"TestUuid"> {
     query?: Q
   ): Promise<Prisma.Result<Prisma.TestUuidDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.TestUuidDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map(async (record) => {
+    const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
       return unsafeRecord;
     });
-    return (await Promise.all(recordsWithRelations)) as Prisma.Result<Prisma.TestUuidDelegate, Q, "findFirstOrThrow">[];
+    return recordsWithRelations as Prisma.Result<Prisma.TestUuidDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.TestUuidDelegate, "findMany">["orderBy"],
@@ -10010,24 +10433,44 @@ class ModelWithOptionalRelationToUniqueAttributesIDBClass extends BaseIDBModelCl
         Q,
         "findFirstOrThrow"
       >[];
-    const recordsWithRelations = records.map(async (record) => {
+    const attach_link = query.select?.link || query.include?.link;
+    let link_hashMap: Map<string, unknown> | undefined;
+    if (attach_link) {
+      const link_opts = (attach_link === true ? {} : attach_link) as Record<string, unknown>;
+      const link_sel = link_opts.select as Record<string, boolean> | undefined;
+      const link_keysToInject = link_sel ? (["id"] as string[]).filter((k) => !link_sel![k]) : [];
+      const link_fkValues = [...new Set(records.map((r) => r.linkId).filter((v) => v !== null && v !== undefined))];
+      const link_related = await this.client.modelWithUniqueAttributes.findMany(
+        {
+          ...link_opts,
+          ...(link_keysToInject.length > 0
+            ? { select: { ...link_sel, ...Object.fromEntries(link_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          where: { id: { in: link_fkValues } },
+        },
+        { tx }
+      );
+      link_hashMap = new Map(
+        link_related.map((r) => {
+          const _r = r as Record<string, unknown>;
+          const key = JSON.stringify(_r["id"]);
+          const value =
+            link_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !link_keysToInject.includes(k)))
+              : _r;
+          return [key, value as unknown];
+        })
+      );
+    }
+    const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
-      const attach_link = query.select?.link || query.include?.link;
       if (attach_link) {
         unsafeRecord["link"] =
-          record.linkId === null
-            ? null
-            : await this.client.modelWithUniqueAttributes.findUnique(
-                {
-                  ...(attach_link === true ? {} : attach_link),
-                  where: { id: record.linkId! },
-                },
-                { tx }
-              );
+          record.linkId === null ? null : (link_hashMap!.get(JSON.stringify(record.linkId)) ?? null);
       }
       return unsafeRecord;
     });
-    return (await Promise.all(recordsWithRelations)) as Prisma.Result<
+    return recordsWithRelations as Prisma.Result<
       Prisma.ModelWithOptionalRelationToUniqueAttributesDelegate,
       Q,
       "findFirstOrThrow"
@@ -10941,25 +11384,60 @@ class ModelWithUniqueAttributesIDBClass extends BaseIDBModelClass<"ModelWithUniq
     query?: Q
   ): Promise<Prisma.Result<Prisma.ModelWithUniqueAttributesDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.ModelWithUniqueAttributesDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map(async (record) => {
+    const attach_links = query.select?.links || query.include?.links;
+    let links_hashMap: Map<string, unknown[]> | undefined;
+    if (attach_links) {
+      const links_opts = (attach_links === true ? {} : attach_links) as Record<string, unknown>;
+      const links_sel = links_opts.select as Record<string, boolean> | undefined;
+      const links_keysToInject = links_sel ? (["linkId"] as string[]).filter((k) => !links_sel![k]) : [];
+      const links_parentIds = [...new Set(records.map((r) => r.id))];
+      const links_allRelated = await this.client.modelWithOptionalRelationToUniqueAttributes.findMany(
+        {
+          ...links_opts,
+          ...(links_keysToInject.length > 0
+            ? { select: { ...links_sel, ...Object.fromEntries(links_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          take: undefined,
+          skip: undefined,
+          where: { linkId: { in: links_parentIds } },
+        },
+        { tx }
+      );
+      const links_take =
+        attach_links !== true
+          ? (attach_links as Prisma.ModelWithOptionalRelationToUniqueAttributesFindManyArgs).take
+          : undefined;
+      const links_skip =
+        attach_links !== true
+          ? (attach_links as Prisma.ModelWithOptionalRelationToUniqueAttributesFindManyArgs).skip
+          : undefined;
+      links_hashMap = new Map<string, unknown[]>();
+      for (const related of links_allRelated) {
+        const _r = related as Record<string, unknown>;
+        const key = JSON.stringify(_r["linkId"]);
+        if (!links_hashMap!.has(key)) links_hashMap!.set(key, []);
+        const value =
+          links_keysToInject.length > 0
+            ? Object.fromEntries(Object.entries(_r).filter(([k]) => !links_keysToInject.includes(k)))
+            : _r;
+        links_hashMap!.get(key)!.push(value as unknown);
+      }
+      if (links_skip !== undefined || links_take !== undefined) {
+        for (const [key, group] of links_hashMap!) {
+          const start = links_skip ?? 0;
+          const end = links_take !== undefined ? start + links_take : undefined;
+          links_hashMap!.set(key, group.slice(start, end));
+        }
+      }
+    }
+    const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
-      const attach_links = query.select?.links || query.include?.links;
       if (attach_links) {
-        unsafeRecord["links"] = await this.client.modelWithOptionalRelationToUniqueAttributes.findMany(
-          {
-            ...(attach_links === true ? {} : attach_links),
-            where: { linkId: record.id! },
-          },
-          { tx }
-        );
+        unsafeRecord["links"] = links_hashMap!.get(JSON.stringify(record.id)) ?? [];
       }
       return unsafeRecord;
     });
-    return (await Promise.all(recordsWithRelations)) as Prisma.Result<
-      Prisma.ModelWithUniqueAttributesDelegate,
-      Q,
-      "findFirstOrThrow"
-    >[];
+    return recordsWithRelations as Prisma.Result<Prisma.ModelWithUniqueAttributesDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.ModelWithUniqueAttributesDelegate, "findMany">["orderBy"],
@@ -11940,35 +12418,75 @@ class UserGroupIDBClass extends BaseIDBModelClass<"UserGroup"> {
     query?: Q
   ): Promise<Prisma.Result<Prisma.UserGroupDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.UserGroupDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map(async (record) => {
+    const attach_group = query.select?.group || query.include?.group;
+    let group_hashMap: Map<string, unknown> | undefined;
+    if (attach_group) {
+      const group_opts = (attach_group === true ? {} : attach_group) as Record<string, unknown>;
+      const group_sel = group_opts.select as Record<string, boolean> | undefined;
+      const group_keysToInject = group_sel ? (["id"] as string[]).filter((k) => !group_sel![k]) : [];
+      const group_fkValues = [...new Set(records.map((r) => r.groupId).filter((v) => v !== null && v !== undefined))];
+      const group_related = await this.client.group.findMany(
+        {
+          ...group_opts,
+          ...(group_keysToInject.length > 0
+            ? { select: { ...group_sel, ...Object.fromEntries(group_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          where: { id: { in: group_fkValues } },
+        },
+        { tx }
+      );
+      group_hashMap = new Map(
+        group_related.map((r) => {
+          const _r = r as Record<string, unknown>;
+          const key = JSON.stringify(_r["id"]);
+          const value =
+            group_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !group_keysToInject.includes(k)))
+              : _r;
+          return [key, value as unknown];
+        })
+      );
+    }
+    const attach_user = query.select?.user || query.include?.user;
+    let user_hashMap: Map<string, unknown> | undefined;
+    if (attach_user) {
+      const user_opts = (attach_user === true ? {} : attach_user) as Record<string, unknown>;
+      const user_sel = user_opts.select as Record<string, boolean> | undefined;
+      const user_keysToInject = user_sel ? (["id"] as string[]).filter((k) => !user_sel![k]) : [];
+      const user_fkValues = [...new Set(records.map((r) => r.userId).filter((v) => v !== null && v !== undefined))];
+      const user_related = await this.client.user.findMany(
+        {
+          ...user_opts,
+          ...(user_keysToInject.length > 0
+            ? { select: { ...user_sel, ...Object.fromEntries(user_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          where: { id: { in: user_fkValues } },
+        },
+        { tx }
+      );
+      user_hashMap = new Map(
+        user_related.map((r) => {
+          const _r = r as Record<string, unknown>;
+          const key = JSON.stringify(_r["id"]);
+          const value =
+            user_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !user_keysToInject.includes(k)))
+              : _r;
+          return [key, value as unknown];
+        })
+      );
+    }
+    const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
-      const attach_group = query.select?.group || query.include?.group;
       if (attach_group) {
-        unsafeRecord["group"] = await this.client.group.findUnique(
-          {
-            ...(attach_group === true ? {} : attach_group),
-            where: { id: record.groupId! },
-          },
-          { tx }
-        );
+        unsafeRecord["group"] = group_hashMap!.get(JSON.stringify(record.groupId)) ?? null;
       }
-      const attach_user = query.select?.user || query.include?.user;
       if (attach_user) {
-        unsafeRecord["user"] = await this.client.user.findUnique(
-          {
-            ...(attach_user === true ? {} : attach_user),
-            where: { id: record.userId! },
-          },
-          { tx }
-        );
+        unsafeRecord["user"] = user_hashMap!.get(JSON.stringify(record.userId)) ?? null;
       }
       return unsafeRecord;
     });
-    return (await Promise.all(recordsWithRelations)) as Prisma.Result<
-      Prisma.UserGroupDelegate,
-      Q,
-      "findFirstOrThrow"
-    >[];
+    return recordsWithRelations as Prisma.Result<Prisma.UserGroupDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.UserGroupDelegate, "findMany">["orderBy"],
@@ -13030,44 +13548,128 @@ class FatherIDBClass extends BaseIDBModelClass<"Father"> {
     query?: Q
   ): Promise<Prisma.Result<Prisma.FatherDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.FatherDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map(async (record) => {
+    const attach_children = query.select?.children || query.include?.children;
+    let children_hashMap: Map<string, unknown[]> | undefined;
+    if (attach_children) {
+      const children_opts = (attach_children === true ? {} : attach_children) as Record<string, unknown>;
+      const children_sel = children_opts.select as Record<string, boolean> | undefined;
+      const children_keysToInject = children_sel
+        ? (["fatherLastName", "fatherFirstName"] as string[]).filter((k) => !children_sel![k])
+        : [];
+      const children_pk0_values = [...new Set(records.map((r) => r.lastName))];
+      const children_pk1_values = [...new Set(records.map((r) => r.firstName))];
+      const children_allRelated = await this.client.child.findMany(
+        {
+          ...children_opts,
+          ...(children_keysToInject.length > 0
+            ? { select: { ...children_sel, ...Object.fromEntries(children_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          take: undefined,
+          skip: undefined,
+          where: { fatherLastName: { in: children_pk0_values }, fatherFirstName: { in: children_pk1_values } },
+        },
+        { tx }
+      );
+      const children_take = attach_children !== true ? (attach_children as Prisma.ChildFindManyArgs).take : undefined;
+      const children_skip = attach_children !== true ? (attach_children as Prisma.ChildFindManyArgs).skip : undefined;
+      children_hashMap = new Map<string, unknown[]>();
+      for (const related of children_allRelated) {
+        const _r = related as Record<string, unknown>;
+        const key = JSON.stringify([_r["fatherLastName"], _r["fatherFirstName"]]);
+        if (!children_hashMap!.has(key)) children_hashMap!.set(key, []);
+        const value =
+          children_keysToInject.length > 0
+            ? Object.fromEntries(Object.entries(_r).filter(([k]) => !children_keysToInject.includes(k)))
+            : _r;
+        children_hashMap!.get(key)!.push(value as unknown);
+      }
+      if (children_skip !== undefined || children_take !== undefined) {
+        for (const [key, group] of children_hashMap!) {
+          const start = children_skip ?? 0;
+          const end = children_take !== undefined ? start + children_take : undefined;
+          children_hashMap!.set(key, group.slice(start, end));
+        }
+      }
+    }
+    const attach_wife = query.select?.wife || query.include?.wife;
+    let wife_hashMap: Map<string, unknown> | undefined;
+    if (attach_wife) {
+      const wife_opts = (attach_wife === true ? {} : attach_wife) as Record<string, unknown>;
+      const wife_sel = wife_opts.select as Record<string, boolean> | undefined;
+      const wife_keysToInject = wife_sel ? (["firstName", "lastName"] as string[]).filter((k) => !wife_sel![k]) : [];
+      const wife_pk0_values = [
+        ...new Set(records.map((r) => r.motherFirstName).filter((v) => v !== null && v !== undefined)),
+      ];
+      const wife_pk1_values = [
+        ...new Set(records.map((r) => r.motherLastName).filter((v) => v !== null && v !== undefined)),
+      ];
+      const wife_related = await this.client.mother.findMany(
+        {
+          ...wife_opts,
+          ...(wife_keysToInject.length > 0
+            ? { select: { ...wife_sel, ...Object.fromEntries(wife_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          where: { firstName: { in: wife_pk0_values }, lastName: { in: wife_pk1_values } },
+        },
+        { tx }
+      );
+      wife_hashMap = new Map(
+        wife_related.map((r) => {
+          const _r = r as Record<string, unknown>;
+          const key = JSON.stringify([_r["firstName"], _r["lastName"]]);
+          const value =
+            wife_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !wife_keysToInject.includes(k)))
+              : _r;
+          return [key, value as unknown];
+        })
+      );
+    }
+    const attach_user = query.select?.user || query.include?.user;
+    let user_hashMap: Map<string, unknown> | undefined;
+    if (attach_user) {
+      const user_opts = (attach_user === true ? {} : attach_user) as Record<string, unknown>;
+      const user_sel = user_opts.select as Record<string, boolean> | undefined;
+      const user_keysToInject = user_sel ? (["id"] as string[]).filter((k) => !user_sel![k]) : [];
+      const user_fkValues = [...new Set(records.map((r) => r.userId).filter((v) => v !== null && v !== undefined))];
+      const user_related = await this.client.user.findMany(
+        {
+          ...user_opts,
+          ...(user_keysToInject.length > 0
+            ? { select: { ...user_sel, ...Object.fromEntries(user_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          where: { id: { in: user_fkValues } },
+        },
+        { tx }
+      );
+      user_hashMap = new Map(
+        user_related.map((r) => {
+          const _r = r as Record<string, unknown>;
+          const key = JSON.stringify(_r["id"]);
+          const value =
+            user_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !user_keysToInject.includes(k)))
+              : _r;
+          return [key, value as unknown];
+        })
+      );
+    }
+    const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
-      const attach_children = query.select?.children || query.include?.children;
       if (attach_children) {
-        unsafeRecord["children"] = await this.client.child.findMany(
-          {
-            ...(attach_children === true ? {} : attach_children),
-            where: { fatherLastName: record.lastName!, fatherFirstName: record.firstName! },
-          },
-          { tx }
-        );
+        unsafeRecord["children"] = children_hashMap!.get(JSON.stringify([record.lastName, record.firstName])) ?? [];
       }
-      const attach_wife = query.select?.wife || query.include?.wife;
       if (attach_wife) {
-        unsafeRecord["wife"] = await this.client.mother.findUnique(
-          {
-            ...(attach_wife === true ? {} : attach_wife),
-            where: { firstName_lastName: { firstName: record.motherFirstName!, lastName: record.motherLastName! } },
-          },
-          { tx }
-        );
+        unsafeRecord["wife"] =
+          wife_hashMap!.get(JSON.stringify([record.motherFirstName, record.motherLastName])) ?? null;
       }
-      const attach_user = query.select?.user || query.include?.user;
       if (attach_user) {
         unsafeRecord["user"] =
-          record.userId === null
-            ? null
-            : await this.client.user.findUnique(
-                {
-                  ...(attach_user === true ? {} : attach_user),
-                  where: { id: record.userId! },
-                },
-                { tx }
-              );
+          record.userId === null ? null : (user_hashMap!.get(JSON.stringify(record.userId)) ?? null);
       }
       return unsafeRecord;
     });
-    return (await Promise.all(recordsWithRelations)) as Prisma.Result<Prisma.FatherDelegate, Q, "findFirstOrThrow">[];
+    return recordsWithRelations as Prisma.Result<Prisma.FatherDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.FatherDelegate, "findMany">["orderBy"],
@@ -14498,46 +15100,125 @@ class MotherIDBClass extends BaseIDBModelClass<"Mother"> {
     query?: Q
   ): Promise<Prisma.Result<Prisma.MotherDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.MotherDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map(async (record) => {
+    const attach_children = query.select?.children || query.include?.children;
+    let children_hashMap: Map<string, unknown[]> | undefined;
+    if (attach_children) {
+      const children_opts = (attach_children === true ? {} : attach_children) as Record<string, unknown>;
+      const children_sel = children_opts.select as Record<string, boolean> | undefined;
+      const children_keysToInject = children_sel
+        ? (["motherFirstName", "motherLastName"] as string[]).filter((k) => !children_sel![k])
+        : [];
+      const children_pk0_values = [...new Set(records.map((r) => r.firstName))];
+      const children_pk1_values = [...new Set(records.map((r) => r.lastName))];
+      const children_allRelated = await this.client.child.findMany(
+        {
+          ...children_opts,
+          ...(children_keysToInject.length > 0
+            ? { select: { ...children_sel, ...Object.fromEntries(children_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          take: undefined,
+          skip: undefined,
+          where: { motherFirstName: { in: children_pk0_values }, motherLastName: { in: children_pk1_values } },
+        },
+        { tx }
+      );
+      const children_take = attach_children !== true ? (attach_children as Prisma.ChildFindManyArgs).take : undefined;
+      const children_skip = attach_children !== true ? (attach_children as Prisma.ChildFindManyArgs).skip : undefined;
+      children_hashMap = new Map<string, unknown[]>();
+      for (const related of children_allRelated) {
+        const _r = related as Record<string, unknown>;
+        const key = JSON.stringify([_r["motherFirstName"], _r["motherLastName"]]);
+        if (!children_hashMap!.has(key)) children_hashMap!.set(key, []);
+        const value =
+          children_keysToInject.length > 0
+            ? Object.fromEntries(Object.entries(_r).filter(([k]) => !children_keysToInject.includes(k)))
+            : _r;
+        children_hashMap!.get(key)!.push(value as unknown);
+      }
+      if (children_skip !== undefined || children_take !== undefined) {
+        for (const [key, group] of children_hashMap!) {
+          const start = children_skip ?? 0;
+          const end = children_take !== undefined ? start + children_take : undefined;
+          children_hashMap!.set(key, group.slice(start, end));
+        }
+      }
+    }
+    const attach_husband = query.select?.husband || query.include?.husband;
+    let husband_hashMap: Map<string, unknown> | undefined;
+    if (attach_husband) {
+      const husband_opts = (attach_husband === true ? {} : attach_husband) as Record<string, unknown>;
+      const husband_sel = husband_opts.select as Record<string, boolean> | undefined;
+      const husband_keysToInject = husband_sel
+        ? (["motherFirstName", "motherLastName"] as string[]).filter((k) => !husband_sel![k])
+        : [];
+      const husband_pk0_values = [...new Set(records.map((r) => r.firstName))];
+      const husband_pk1_values = [...new Set(records.map((r) => r.lastName))];
+      const husband_related = await this.client.father.findMany(
+        {
+          ...husband_opts,
+          ...(husband_keysToInject.length > 0
+            ? { select: { ...husband_sel, ...Object.fromEntries(husband_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          where: { motherFirstName: { in: husband_pk0_values }, motherLastName: { in: husband_pk1_values } },
+        },
+        { tx }
+      );
+      husband_hashMap = new Map(
+        husband_related.map((r) => {
+          const _r = r as Record<string, unknown>;
+          const key = JSON.stringify([_r["motherFirstName"], _r["motherLastName"]]);
+          const value =
+            husband_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !husband_keysToInject.includes(k)))
+              : _r;
+          return [key, value as unknown];
+        })
+      );
+    }
+    const attach_user = query.select?.user || query.include?.user;
+    let user_hashMap: Map<string, unknown> | undefined;
+    if (attach_user) {
+      const user_opts = (attach_user === true ? {} : attach_user) as Record<string, unknown>;
+      const user_sel = user_opts.select as Record<string, boolean> | undefined;
+      const user_keysToInject = user_sel ? (["id"] as string[]).filter((k) => !user_sel![k]) : [];
+      const user_fkValues = [...new Set(records.map((r) => r.userId).filter((v) => v !== null && v !== undefined))];
+      const user_related = await this.client.user.findMany(
+        {
+          ...user_opts,
+          ...(user_keysToInject.length > 0
+            ? { select: { ...user_sel, ...Object.fromEntries(user_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          where: { id: { in: user_fkValues } },
+        },
+        { tx }
+      );
+      user_hashMap = new Map(
+        user_related.map((r) => {
+          const _r = r as Record<string, unknown>;
+          const key = JSON.stringify(_r["id"]);
+          const value =
+            user_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !user_keysToInject.includes(k)))
+              : _r;
+          return [key, value as unknown];
+        })
+      );
+    }
+    const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
-      const attach_children = query.select?.children || query.include?.children;
       if (attach_children) {
-        unsafeRecord["children"] = await this.client.child.findMany(
-          {
-            ...(attach_children === true ? {} : attach_children),
-            where: { motherFirstName: record.firstName!, motherLastName: record.lastName! },
-          },
-          { tx }
-        );
+        unsafeRecord["children"] = children_hashMap!.get(JSON.stringify([record.firstName, record.lastName])) ?? [];
       }
-      const attach_husband = query.select?.husband || query.include?.husband;
       if (attach_husband) {
-        unsafeRecord["husband"] = await this.client.father.findUnique(
-          {
-            ...(attach_husband === true ? {} : attach_husband),
-            where: {
-              motherFirstName_motherLastName: { motherFirstName: record.firstName, motherLastName: record.lastName },
-            },
-          },
-          { tx }
-        );
+        unsafeRecord["husband"] = husband_hashMap!.get(JSON.stringify([record.firstName, record.lastName])) ?? null;
       }
-      const attach_user = query.select?.user || query.include?.user;
       if (attach_user) {
         unsafeRecord["user"] =
-          record.userId === null
-            ? null
-            : await this.client.user.findUnique(
-                {
-                  ...(attach_user === true ? {} : attach_user),
-                  where: { id: record.userId! },
-                },
-                { tx }
-              );
+          record.userId === null ? null : (user_hashMap!.get(JSON.stringify(record.userId)) ?? null);
       }
       return unsafeRecord;
     });
-    return (await Promise.all(recordsWithRelations)) as Prisma.Result<Prisma.MotherDelegate, Q, "findFirstOrThrow">[];
+    return recordsWithRelations as Prisma.Result<Prisma.MotherDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.MotherDelegate, "findMany">["orderBy"],
@@ -15957,44 +16638,124 @@ class ChildIDBClass extends BaseIDBModelClass<"Child"> {
     query?: Q
   ): Promise<Prisma.Result<Prisma.ChildDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.ChildDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map(async (record) => {
+    const attach_user = query.select?.user || query.include?.user;
+    let user_hashMap: Map<string, unknown> | undefined;
+    if (attach_user) {
+      const user_opts = (attach_user === true ? {} : attach_user) as Record<string, unknown>;
+      const user_sel = user_opts.select as Record<string, boolean> | undefined;
+      const user_keysToInject = user_sel ? (["id"] as string[]).filter((k) => !user_sel![k]) : [];
+      const user_fkValues = [...new Set(records.map((r) => r.userId).filter((v) => v !== null && v !== undefined))];
+      const user_related = await this.client.user.findMany(
+        {
+          ...user_opts,
+          ...(user_keysToInject.length > 0
+            ? { select: { ...user_sel, ...Object.fromEntries(user_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          where: { id: { in: user_fkValues } },
+        },
+        { tx }
+      );
+      user_hashMap = new Map(
+        user_related.map((r) => {
+          const _r = r as Record<string, unknown>;
+          const key = JSON.stringify(_r["id"]);
+          const value =
+            user_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !user_keysToInject.includes(k)))
+              : _r;
+          return [key, value as unknown];
+        })
+      );
+    }
+    const attach_father = query.select?.father || query.include?.father;
+    let father_hashMap: Map<string, unknown> | undefined;
+    if (attach_father) {
+      const father_opts = (attach_father === true ? {} : attach_father) as Record<string, unknown>;
+      const father_sel = father_opts.select as Record<string, boolean> | undefined;
+      const father_keysToInject = father_sel
+        ? (["lastName", "firstName"] as string[]).filter((k) => !father_sel![k])
+        : [];
+      const father_pk0_values = [
+        ...new Set(records.map((r) => r.fatherLastName).filter((v) => v !== null && v !== undefined)),
+      ];
+      const father_pk1_values = [
+        ...new Set(records.map((r) => r.fatherFirstName).filter((v) => v !== null && v !== undefined)),
+      ];
+      const father_related = await this.client.father.findMany(
+        {
+          ...father_opts,
+          ...(father_keysToInject.length > 0
+            ? { select: { ...father_sel, ...Object.fromEntries(father_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          where: { lastName: { in: father_pk0_values }, firstName: { in: father_pk1_values } },
+        },
+        { tx }
+      );
+      father_hashMap = new Map(
+        father_related.map((r) => {
+          const _r = r as Record<string, unknown>;
+          const key = JSON.stringify([_r["lastName"], _r["firstName"]]);
+          const value =
+            father_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !father_keysToInject.includes(k)))
+              : _r;
+          return [key, value as unknown];
+        })
+      );
+    }
+    const attach_mother = query.select?.mother || query.include?.mother;
+    let mother_hashMap: Map<string, unknown> | undefined;
+    if (attach_mother) {
+      const mother_opts = (attach_mother === true ? {} : attach_mother) as Record<string, unknown>;
+      const mother_sel = mother_opts.select as Record<string, boolean> | undefined;
+      const mother_keysToInject = mother_sel
+        ? (["firstName", "lastName"] as string[]).filter((k) => !mother_sel![k])
+        : [];
+      const mother_pk0_values = [
+        ...new Set(records.map((r) => r.motherFirstName).filter((v) => v !== null && v !== undefined)),
+      ];
+      const mother_pk1_values = [
+        ...new Set(records.map((r) => r.motherLastName).filter((v) => v !== null && v !== undefined)),
+      ];
+      const mother_related = await this.client.mother.findMany(
+        {
+          ...mother_opts,
+          ...(mother_keysToInject.length > 0
+            ? { select: { ...mother_sel, ...Object.fromEntries(mother_keysToInject.map((k) => [k, true])) } }
+            : {}),
+          where: { firstName: { in: mother_pk0_values }, lastName: { in: mother_pk1_values } },
+        },
+        { tx }
+      );
+      mother_hashMap = new Map(
+        mother_related.map((r) => {
+          const _r = r as Record<string, unknown>;
+          const key = JSON.stringify([_r["firstName"], _r["lastName"]]);
+          const value =
+            mother_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !mother_keysToInject.includes(k)))
+              : _r;
+          return [key, value as unknown];
+        })
+      );
+    }
+    const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
-      const attach_user = query.select?.user || query.include?.user;
       if (attach_user) {
         unsafeRecord["user"] =
-          record.userId === null
-            ? null
-            : await this.client.user.findUnique(
-                {
-                  ...(attach_user === true ? {} : attach_user),
-                  where: { id: record.userId! },
-                },
-                { tx }
-              );
+          record.userId === null ? null : (user_hashMap!.get(JSON.stringify(record.userId)) ?? null);
       }
-      const attach_father = query.select?.father || query.include?.father;
       if (attach_father) {
-        unsafeRecord["father"] = await this.client.father.findUnique(
-          {
-            ...(attach_father === true ? {} : attach_father),
-            where: { firstName_lastName: { firstName: record.fatherFirstName!, lastName: record.fatherLastName! } },
-          },
-          { tx }
-        );
+        unsafeRecord["father"] =
+          father_hashMap!.get(JSON.stringify([record.fatherLastName, record.fatherFirstName])) ?? null;
       }
-      const attach_mother = query.select?.mother || query.include?.mother;
       if (attach_mother) {
-        unsafeRecord["mother"] = await this.client.mother.findUnique(
-          {
-            ...(attach_mother === true ? {} : attach_mother),
-            where: { firstName_lastName: { firstName: record.motherFirstName!, lastName: record.motherLastName! } },
-          },
-          { tx }
-        );
+        unsafeRecord["mother"] =
+          mother_hashMap!.get(JSON.stringify([record.motherFirstName, record.motherLastName])) ?? null;
       }
       return unsafeRecord;
     });
-    return (await Promise.all(recordsWithRelations)) as Prisma.Result<Prisma.ChildDelegate, Q, "findFirstOrThrow">[];
+    return recordsWithRelations as Prisma.Result<Prisma.ChildDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.ChildDelegate, "findMany">["orderBy"],
@@ -17262,15 +18023,11 @@ class CompositeIdIntStringIDBClass extends BaseIDBModelClass<"CompositeIdIntStri
     query?: Q
   ): Promise<Prisma.Result<Prisma.CompositeIdIntStringDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.CompositeIdIntStringDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map(async (record) => {
+    const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
       return unsafeRecord;
     });
-    return (await Promise.all(recordsWithRelations)) as Prisma.Result<
-      Prisma.CompositeIdIntStringDelegate,
-      Q,
-      "findFirstOrThrow"
-    >[];
+    return recordsWithRelations as Prisma.Result<Prisma.CompositeIdIntStringDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.CompositeIdIntStringDelegate, "findMany">["orderBy"],
@@ -17893,15 +18650,11 @@ class CompositeIdWithDateTimeIDBClass extends BaseIDBModelClass<"CompositeIdWith
     query?: Q
   ): Promise<Prisma.Result<Prisma.CompositeIdWithDateTimeDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.CompositeIdWithDateTimeDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map(async (record) => {
+    const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
       return unsafeRecord;
     });
-    return (await Promise.all(recordsWithRelations)) as Prisma.Result<
-      Prisma.CompositeIdWithDateTimeDelegate,
-      Q,
-      "findFirstOrThrow"
-    >[];
+    return recordsWithRelations as Prisma.Result<Prisma.CompositeIdWithDateTimeDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.CompositeIdWithDateTimeDelegate, "findMany">["orderBy"],
@@ -18532,15 +19285,11 @@ class TripleCompositeIdWithDateIDBClass extends BaseIDBModelClass<"TripleComposi
     query?: Q
   ): Promise<Prisma.Result<Prisma.TripleCompositeIdWithDateDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.TripleCompositeIdWithDateDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map(async (record) => {
+    const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
       return unsafeRecord;
     });
-    return (await Promise.all(recordsWithRelations)) as Prisma.Result<
-      Prisma.TripleCompositeIdWithDateDelegate,
-      Q,
-      "findFirstOrThrow"
-    >[];
+    return recordsWithRelations as Prisma.Result<Prisma.TripleCompositeIdWithDateDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.TripleCompositeIdWithDateDelegate, "findMany">["orderBy"],
@@ -19228,15 +19977,11 @@ class CompositeUniqueWithDateTimeIDBClass extends BaseIDBModelClass<"CompositeUn
     query?: Q
   ): Promise<Prisma.Result<Prisma.CompositeUniqueWithDateTimeDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.CompositeUniqueWithDateTimeDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map(async (record) => {
+    const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
       return unsafeRecord;
     });
-    return (await Promise.all(recordsWithRelations)) as Prisma.Result<
-      Prisma.CompositeUniqueWithDateTimeDelegate,
-      Q,
-      "findFirstOrThrow"
-    >[];
+    return recordsWithRelations as Prisma.Result<Prisma.CompositeUniqueWithDateTimeDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.CompositeUniqueWithDateTimeDelegate, "findMany">["orderBy"],
@@ -19899,15 +20644,11 @@ class CompositeUniqueFloatIntIDBClass extends BaseIDBModelClass<"CompositeUnique
     query?: Q
   ): Promise<Prisma.Result<Prisma.CompositeUniqueFloatIntDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.CompositeUniqueFloatIntDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map(async (record) => {
+    const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
       return unsafeRecord;
     });
-    return (await Promise.all(recordsWithRelations)) as Prisma.Result<
-      Prisma.CompositeUniqueFloatIntDelegate,
-      Q,
-      "findFirstOrThrow"
-    >[];
+    return recordsWithRelations as Prisma.Result<Prisma.CompositeUniqueFloatIntDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.CompositeUniqueFloatIntDelegate, "findMany">["orderBy"],
@@ -20563,15 +21304,11 @@ class MultipleCompositeUniquesIDBClass extends BaseIDBModelClass<"MultipleCompos
     query?: Q
   ): Promise<Prisma.Result<Prisma.MultipleCompositeUniquesDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.MultipleCompositeUniquesDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map(async (record) => {
+    const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
       return unsafeRecord;
     });
-    return (await Promise.all(recordsWithRelations)) as Prisma.Result<
-      Prisma.MultipleCompositeUniquesDelegate,
-      Q,
-      "findFirstOrThrow"
-    >[];
+    return recordsWithRelations as Prisma.Result<Prisma.MultipleCompositeUniquesDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.MultipleCompositeUniquesDelegate, "findMany">["orderBy"],
@@ -21287,15 +22024,11 @@ class ModelWithIndexIDBClass extends BaseIDBModelClass<"ModelWithIndex"> {
     query?: Q
   ): Promise<Prisma.Result<Prisma.ModelWithIndexDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.ModelWithIndexDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map(async (record) => {
+    const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
       return unsafeRecord;
     });
-    return (await Promise.all(recordsWithRelations)) as Prisma.Result<
-      Prisma.ModelWithIndexDelegate,
-      Q,
-      "findFirstOrThrow"
-    >[];
+    return recordsWithRelations as Prisma.Result<Prisma.ModelWithIndexDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.ModelWithIndexDelegate, "findMany">["orderBy"],

--- a/apps/usage/src/lib/prisma-idb/client/prisma-idb-client.ts
+++ b/apps/usage/src/lib/prisma-idb/client/prisma-idb-client.ts
@@ -8882,11 +8882,7 @@ class AllFieldScalarTypesIDBClass extends BaseIDBModelClass<"AllFieldScalarTypes
     query?: Q
   ): Promise<Prisma.Result<Prisma.AllFieldScalarTypesDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.AllFieldScalarTypesDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map((record) => {
-      const unsafeRecord = record as Record<string, unknown>;
-      return unsafeRecord;
-    });
-    return recordsWithRelations as Prisma.Result<Prisma.AllFieldScalarTypesDelegate, Q, "findFirstOrThrow">[];
+    return records as Prisma.Result<Prisma.AllFieldScalarTypesDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.AllFieldScalarTypesDelegate, "findMany">["orderBy"],
@@ -9616,11 +9612,7 @@ class ModelWithEnumIDBClass extends BaseIDBModelClass<"ModelWithEnum"> {
     query?: Q
   ): Promise<Prisma.Result<Prisma.ModelWithEnumDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.ModelWithEnumDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map((record) => {
-      const unsafeRecord = record as Record<string, unknown>;
-      return unsafeRecord;
-    });
-    return recordsWithRelations as Prisma.Result<Prisma.ModelWithEnumDelegate, Q, "findFirstOrThrow">[];
+    return records as Prisma.Result<Prisma.ModelWithEnumDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.ModelWithEnumDelegate, "findMany">["orderBy"],
@@ -10221,11 +10213,7 @@ class TestUuidIDBClass extends BaseIDBModelClass<"TestUuid"> {
     query?: Q
   ): Promise<Prisma.Result<Prisma.TestUuidDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.TestUuidDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map((record) => {
-      const unsafeRecord = record as Record<string, unknown>;
-      return unsafeRecord;
-    });
-    return recordsWithRelations as Prisma.Result<Prisma.TestUuidDelegate, Q, "findFirstOrThrow">[];
+    return records as Prisma.Result<Prisma.TestUuidDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.TestUuidDelegate, "findMany">["orderBy"],
@@ -18637,11 +18625,7 @@ class CompositeIdIntStringIDBClass extends BaseIDBModelClass<"CompositeIdIntStri
     query?: Q
   ): Promise<Prisma.Result<Prisma.CompositeIdIntStringDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.CompositeIdIntStringDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map((record) => {
-      const unsafeRecord = record as Record<string, unknown>;
-      return unsafeRecord;
-    });
-    return recordsWithRelations as Prisma.Result<Prisma.CompositeIdIntStringDelegate, Q, "findFirstOrThrow">[];
+    return records as Prisma.Result<Prisma.CompositeIdIntStringDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.CompositeIdIntStringDelegate, "findMany">["orderBy"],
@@ -19264,11 +19248,7 @@ class CompositeIdWithDateTimeIDBClass extends BaseIDBModelClass<"CompositeIdWith
     query?: Q
   ): Promise<Prisma.Result<Prisma.CompositeIdWithDateTimeDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.CompositeIdWithDateTimeDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map((record) => {
-      const unsafeRecord = record as Record<string, unknown>;
-      return unsafeRecord;
-    });
-    return recordsWithRelations as Prisma.Result<Prisma.CompositeIdWithDateTimeDelegate, Q, "findFirstOrThrow">[];
+    return records as Prisma.Result<Prisma.CompositeIdWithDateTimeDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.CompositeIdWithDateTimeDelegate, "findMany">["orderBy"],
@@ -19899,11 +19879,7 @@ class TripleCompositeIdWithDateIDBClass extends BaseIDBModelClass<"TripleComposi
     query?: Q
   ): Promise<Prisma.Result<Prisma.TripleCompositeIdWithDateDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.TripleCompositeIdWithDateDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map((record) => {
-      const unsafeRecord = record as Record<string, unknown>;
-      return unsafeRecord;
-    });
-    return recordsWithRelations as Prisma.Result<Prisma.TripleCompositeIdWithDateDelegate, Q, "findFirstOrThrow">[];
+    return records as Prisma.Result<Prisma.TripleCompositeIdWithDateDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.TripleCompositeIdWithDateDelegate, "findMany">["orderBy"],
@@ -20591,11 +20567,7 @@ class CompositeUniqueWithDateTimeIDBClass extends BaseIDBModelClass<"CompositeUn
     query?: Q
   ): Promise<Prisma.Result<Prisma.CompositeUniqueWithDateTimeDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.CompositeUniqueWithDateTimeDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map((record) => {
-      const unsafeRecord = record as Record<string, unknown>;
-      return unsafeRecord;
-    });
-    return recordsWithRelations as Prisma.Result<Prisma.CompositeUniqueWithDateTimeDelegate, Q, "findFirstOrThrow">[];
+    return records as Prisma.Result<Prisma.CompositeUniqueWithDateTimeDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.CompositeUniqueWithDateTimeDelegate, "findMany">["orderBy"],
@@ -21258,11 +21230,7 @@ class CompositeUniqueFloatIntIDBClass extends BaseIDBModelClass<"CompositeUnique
     query?: Q
   ): Promise<Prisma.Result<Prisma.CompositeUniqueFloatIntDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.CompositeUniqueFloatIntDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map((record) => {
-      const unsafeRecord = record as Record<string, unknown>;
-      return unsafeRecord;
-    });
-    return recordsWithRelations as Prisma.Result<Prisma.CompositeUniqueFloatIntDelegate, Q, "findFirstOrThrow">[];
+    return records as Prisma.Result<Prisma.CompositeUniqueFloatIntDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.CompositeUniqueFloatIntDelegate, "findMany">["orderBy"],
@@ -21918,11 +21886,7 @@ class MultipleCompositeUniquesIDBClass extends BaseIDBModelClass<"MultipleCompos
     query?: Q
   ): Promise<Prisma.Result<Prisma.MultipleCompositeUniquesDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.MultipleCompositeUniquesDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map((record) => {
-      const unsafeRecord = record as Record<string, unknown>;
-      return unsafeRecord;
-    });
-    return recordsWithRelations as Prisma.Result<Prisma.MultipleCompositeUniquesDelegate, Q, "findFirstOrThrow">[];
+    return records as Prisma.Result<Prisma.MultipleCompositeUniquesDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.MultipleCompositeUniquesDelegate, "findMany">["orderBy"],
@@ -22638,11 +22602,7 @@ class ModelWithIndexIDBClass extends BaseIDBModelClass<"ModelWithIndex"> {
     query?: Q
   ): Promise<Prisma.Result<Prisma.ModelWithIndexDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.ModelWithIndexDelegate, Q, "findFirstOrThrow">[];
-    const recordsWithRelations = records.map((record) => {
-      const unsafeRecord = record as Record<string, unknown>;
-      return unsafeRecord;
-    });
-    return recordsWithRelations as Prisma.Result<Prisma.ModelWithIndexDelegate, Q, "findFirstOrThrow">[];
+    return records as Prisma.Result<Prisma.ModelWithIndexDelegate, Q, "findFirstOrThrow">[];
   }
   async _applyOrderByClause<
     O extends Prisma.Args<Prisma.ModelWithIndexDelegate, "findMany">["orderBy"],

--- a/apps/usage/src/lib/prisma-idb/client/prisma-idb-client.ts
+++ b/apps/usage/src/lib/prisma-idb/client/prisma-idb-client.ts
@@ -540,13 +540,16 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
       const profile_sel = profile_opts.select as Record<string, boolean> | undefined;
       const profile_keysToInject = profile_sel ? (["userId"] as string[]).filter((k) => !profile_sel![k]) : [];
       const profile_parentIds = [...new Set(records.map((r) => r.id))];
+      const profile_userWhere = profile_opts.where as Record<string, unknown> | undefined;
+      const profile_fkWhere = { userId: { in: profile_parentIds } };
+      const profile_where = profile_userWhere ? { AND: [profile_userWhere, profile_fkWhere] } : profile_fkWhere;
       const profile_related = await this.client.profile.findMany(
         {
           ...profile_opts,
           ...(profile_keysToInject.length > 0
             ? { select: { ...profile_sel, ...Object.fromEntries(profile_keysToInject.map((k) => [k, true])) } }
             : {}),
-          where: { userId: { in: profile_parentIds } },
+          where: profile_where,
         },
         { tx }
       );
@@ -568,37 +571,70 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
       const posts_opts = (attach_posts === true ? {} : attach_posts) as Record<string, unknown>;
       const posts_sel = posts_opts.select as Record<string, boolean> | undefined;
       const posts_keysToInject = posts_sel ? (["authorId"] as string[]).filter((k) => !posts_sel![k]) : [];
+      const posts_take = posts_opts.take as number | undefined;
+      const posts_skip = posts_opts.skip as number | undefined;
+      const posts_cursor = posts_opts.cursor;
+      const posts_distinct = posts_opts.distinct;
       const posts_parentIds = [...new Set(records.map((r) => r.id))];
-      const posts_allRelated = await this.client.post.findMany(
-        {
-          ...posts_opts,
-          ...(posts_keysToInject.length > 0
-            ? { select: { ...posts_sel, ...Object.fromEntries(posts_keysToInject.map((k) => [k, true])) } }
-            : {}),
-          take: undefined,
-          skip: undefined,
-          where: { authorId: { in: posts_parentIds } },
-        },
-        { tx }
-      );
-      const posts_take = attach_posts !== true ? (attach_posts as Prisma.PostFindManyArgs).take : undefined;
-      const posts_skip = attach_posts !== true ? (attach_posts as Prisma.PostFindManyArgs).skip : undefined;
       posts_hashMap = new Map<string, unknown[]>();
-      for (const related of posts_allRelated) {
-        const _r = related as Record<string, unknown>;
-        const key = JSON.stringify(_r["authorId"]);
-        if (!posts_hashMap!.has(key)) posts_hashMap!.set(key, []);
-        const value =
-          posts_keysToInject.length > 0
-            ? Object.fromEntries(Object.entries(_r).filter(([k]) => !posts_keysToInject.includes(k)))
-            : _r;
-        posts_hashMap!.get(key)!.push(value as unknown);
-      }
-      if (posts_skip !== undefined || posts_take !== undefined) {
-        for (const [key, group] of posts_hashMap!) {
-          const start = posts_skip ?? 0;
-          const end = posts_take !== undefined ? start + posts_take : undefined;
-          posts_hashMap!.set(key, group.slice(start, end));
+      const posts_userWhere = posts_opts.where as Record<string, unknown> | undefined;
+      if (posts_cursor !== undefined || posts_distinct !== undefined) {
+        for (const parentId of posts_parentIds) {
+          const posts_perParentFkWhere = { authorId: parentId };
+          const posts_perParentWhere = posts_userWhere
+            ? { AND: [posts_userWhere, posts_perParentFkWhere] }
+            : posts_perParentFkWhere;
+          const children = await this.client.post.findMany(
+            {
+              ...posts_opts,
+              ...(posts_keysToInject.length > 0
+                ? { select: { ...posts_sel, ...Object.fromEntries(posts_keysToInject.map((k) => [k, true])) } }
+                : {}),
+              where: posts_perParentWhere,
+            },
+            { tx }
+          );
+          const stripped = children.map((c) => {
+            const _r = c as Record<string, unknown>;
+            return posts_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !posts_keysToInject.includes(k)))
+              : _r;
+          });
+          posts_hashMap!.set(JSON.stringify(parentId), stripped as unknown[]);
+        }
+      } else {
+        const posts_fkWhere = { authorId: { in: posts_parentIds } };
+        const posts_where = posts_userWhere ? { AND: [posts_userWhere, posts_fkWhere] } : posts_fkWhere;
+        const posts_allRelated = await this.client.post.findMany(
+          {
+            ...posts_opts,
+            ...(posts_keysToInject.length > 0
+              ? { select: { ...posts_sel, ...Object.fromEntries(posts_keysToInject.map((k) => [k, true])) } }
+              : {}),
+            take: undefined,
+            skip: undefined,
+            where: posts_where,
+          },
+          { tx }
+        );
+        for (const related of posts_allRelated) {
+          const _r = related as Record<string, unknown>;
+          const key = JSON.stringify(_r["authorId"]);
+          if (!posts_hashMap!.has(key)) posts_hashMap!.set(key, []);
+          const value =
+            posts_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !posts_keysToInject.includes(k)))
+              : _r;
+          posts_hashMap!.get(key)!.push(value as unknown);
+        }
+        if (posts_skip !== undefined || posts_take !== undefined) {
+          for (const [key, group] of posts_hashMap!) {
+            let sliced = group;
+            if (posts_skip !== undefined) sliced = sliced.slice(posts_skip);
+            if (posts_take !== undefined)
+              sliced = posts_take < 0 ? sliced.slice(posts_take) : sliced.slice(0, posts_take);
+            posts_hashMap!.set(key, sliced);
+          }
         }
       }
     }
@@ -608,37 +644,70 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
       const comments_opts = (attach_comments === true ? {} : attach_comments) as Record<string, unknown>;
       const comments_sel = comments_opts.select as Record<string, boolean> | undefined;
       const comments_keysToInject = comments_sel ? (["userId"] as string[]).filter((k) => !comments_sel![k]) : [];
+      const comments_take = comments_opts.take as number | undefined;
+      const comments_skip = comments_opts.skip as number | undefined;
+      const comments_cursor = comments_opts.cursor;
+      const comments_distinct = comments_opts.distinct;
       const comments_parentIds = [...new Set(records.map((r) => r.id))];
-      const comments_allRelated = await this.client.comment.findMany(
-        {
-          ...comments_opts,
-          ...(comments_keysToInject.length > 0
-            ? { select: { ...comments_sel, ...Object.fromEntries(comments_keysToInject.map((k) => [k, true])) } }
-            : {}),
-          take: undefined,
-          skip: undefined,
-          where: { userId: { in: comments_parentIds } },
-        },
-        { tx }
-      );
-      const comments_take = attach_comments !== true ? (attach_comments as Prisma.CommentFindManyArgs).take : undefined;
-      const comments_skip = attach_comments !== true ? (attach_comments as Prisma.CommentFindManyArgs).skip : undefined;
       comments_hashMap = new Map<string, unknown[]>();
-      for (const related of comments_allRelated) {
-        const _r = related as Record<string, unknown>;
-        const key = JSON.stringify(_r["userId"]);
-        if (!comments_hashMap!.has(key)) comments_hashMap!.set(key, []);
-        const value =
-          comments_keysToInject.length > 0
-            ? Object.fromEntries(Object.entries(_r).filter(([k]) => !comments_keysToInject.includes(k)))
-            : _r;
-        comments_hashMap!.get(key)!.push(value as unknown);
-      }
-      if (comments_skip !== undefined || comments_take !== undefined) {
-        for (const [key, group] of comments_hashMap!) {
-          const start = comments_skip ?? 0;
-          const end = comments_take !== undefined ? start + comments_take : undefined;
-          comments_hashMap!.set(key, group.slice(start, end));
+      const comments_userWhere = comments_opts.where as Record<string, unknown> | undefined;
+      if (comments_cursor !== undefined || comments_distinct !== undefined) {
+        for (const parentId of comments_parentIds) {
+          const comments_perParentFkWhere = { userId: parentId };
+          const comments_perParentWhere = comments_userWhere
+            ? { AND: [comments_userWhere, comments_perParentFkWhere] }
+            : comments_perParentFkWhere;
+          const children = await this.client.comment.findMany(
+            {
+              ...comments_opts,
+              ...(comments_keysToInject.length > 0
+                ? { select: { ...comments_sel, ...Object.fromEntries(comments_keysToInject.map((k) => [k, true])) } }
+                : {}),
+              where: comments_perParentWhere,
+            },
+            { tx }
+          );
+          const stripped = children.map((c) => {
+            const _r = c as Record<string, unknown>;
+            return comments_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !comments_keysToInject.includes(k)))
+              : _r;
+          });
+          comments_hashMap!.set(JSON.stringify(parentId), stripped as unknown[]);
+        }
+      } else {
+        const comments_fkWhere = { userId: { in: comments_parentIds } };
+        const comments_where = comments_userWhere ? { AND: [comments_userWhere, comments_fkWhere] } : comments_fkWhere;
+        const comments_allRelated = await this.client.comment.findMany(
+          {
+            ...comments_opts,
+            ...(comments_keysToInject.length > 0
+              ? { select: { ...comments_sel, ...Object.fromEntries(comments_keysToInject.map((k) => [k, true])) } }
+              : {}),
+            take: undefined,
+            skip: undefined,
+            where: comments_where,
+          },
+          { tx }
+        );
+        for (const related of comments_allRelated) {
+          const _r = related as Record<string, unknown>;
+          const key = JSON.stringify(_r["userId"]);
+          if (!comments_hashMap!.has(key)) comments_hashMap!.set(key, []);
+          const value =
+            comments_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !comments_keysToInject.includes(k)))
+              : _r;
+          comments_hashMap!.get(key)!.push(value as unknown);
+        }
+        if (comments_skip !== undefined || comments_take !== undefined) {
+          for (const [key, group] of comments_hashMap!) {
+            let sliced = group;
+            if (comments_skip !== undefined) sliced = sliced.slice(comments_skip);
+            if (comments_take !== undefined)
+              sliced = comments_take < 0 ? sliced.slice(comments_take) : sliced.slice(0, comments_take);
+            comments_hashMap!.set(key, sliced);
+          }
         }
       }
     }
@@ -648,37 +717,70 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
       const Child_opts = (attach_Child === true ? {} : attach_Child) as Record<string, unknown>;
       const Child_sel = Child_opts.select as Record<string, boolean> | undefined;
       const Child_keysToInject = Child_sel ? (["userId"] as string[]).filter((k) => !Child_sel![k]) : [];
+      const Child_take = Child_opts.take as number | undefined;
+      const Child_skip = Child_opts.skip as number | undefined;
+      const Child_cursor = Child_opts.cursor;
+      const Child_distinct = Child_opts.distinct;
       const Child_parentIds = [...new Set(records.map((r) => r.id))];
-      const Child_allRelated = await this.client.child.findMany(
-        {
-          ...Child_opts,
-          ...(Child_keysToInject.length > 0
-            ? { select: { ...Child_sel, ...Object.fromEntries(Child_keysToInject.map((k) => [k, true])) } }
-            : {}),
-          take: undefined,
-          skip: undefined,
-          where: { userId: { in: Child_parentIds } },
-        },
-        { tx }
-      );
-      const Child_take = attach_Child !== true ? (attach_Child as Prisma.ChildFindManyArgs).take : undefined;
-      const Child_skip = attach_Child !== true ? (attach_Child as Prisma.ChildFindManyArgs).skip : undefined;
       Child_hashMap = new Map<string, unknown[]>();
-      for (const related of Child_allRelated) {
-        const _r = related as Record<string, unknown>;
-        const key = JSON.stringify(_r["userId"]);
-        if (!Child_hashMap!.has(key)) Child_hashMap!.set(key, []);
-        const value =
-          Child_keysToInject.length > 0
-            ? Object.fromEntries(Object.entries(_r).filter(([k]) => !Child_keysToInject.includes(k)))
-            : _r;
-        Child_hashMap!.get(key)!.push(value as unknown);
-      }
-      if (Child_skip !== undefined || Child_take !== undefined) {
-        for (const [key, group] of Child_hashMap!) {
-          const start = Child_skip ?? 0;
-          const end = Child_take !== undefined ? start + Child_take : undefined;
-          Child_hashMap!.set(key, group.slice(start, end));
+      const Child_userWhere = Child_opts.where as Record<string, unknown> | undefined;
+      if (Child_cursor !== undefined || Child_distinct !== undefined) {
+        for (const parentId of Child_parentIds) {
+          const Child_perParentFkWhere = { userId: parentId };
+          const Child_perParentWhere = Child_userWhere
+            ? { AND: [Child_userWhere, Child_perParentFkWhere] }
+            : Child_perParentFkWhere;
+          const children = await this.client.child.findMany(
+            {
+              ...Child_opts,
+              ...(Child_keysToInject.length > 0
+                ? { select: { ...Child_sel, ...Object.fromEntries(Child_keysToInject.map((k) => [k, true])) } }
+                : {}),
+              where: Child_perParentWhere,
+            },
+            { tx }
+          );
+          const stripped = children.map((c) => {
+            const _r = c as Record<string, unknown>;
+            return Child_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !Child_keysToInject.includes(k)))
+              : _r;
+          });
+          Child_hashMap!.set(JSON.stringify(parentId), stripped as unknown[]);
+        }
+      } else {
+        const Child_fkWhere = { userId: { in: Child_parentIds } };
+        const Child_where = Child_userWhere ? { AND: [Child_userWhere, Child_fkWhere] } : Child_fkWhere;
+        const Child_allRelated = await this.client.child.findMany(
+          {
+            ...Child_opts,
+            ...(Child_keysToInject.length > 0
+              ? { select: { ...Child_sel, ...Object.fromEntries(Child_keysToInject.map((k) => [k, true])) } }
+              : {}),
+            take: undefined,
+            skip: undefined,
+            where: Child_where,
+          },
+          { tx }
+        );
+        for (const related of Child_allRelated) {
+          const _r = related as Record<string, unknown>;
+          const key = JSON.stringify(_r["userId"]);
+          if (!Child_hashMap!.has(key)) Child_hashMap!.set(key, []);
+          const value =
+            Child_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !Child_keysToInject.includes(k)))
+              : _r;
+          Child_hashMap!.get(key)!.push(value as unknown);
+        }
+        if (Child_skip !== undefined || Child_take !== undefined) {
+          for (const [key, group] of Child_hashMap!) {
+            let sliced = group;
+            if (Child_skip !== undefined) sliced = sliced.slice(Child_skip);
+            if (Child_take !== undefined)
+              sliced = Child_take < 0 ? sliced.slice(Child_take) : sliced.slice(0, Child_take);
+            Child_hashMap!.set(key, sliced);
+          }
         }
       }
     }
@@ -688,37 +790,70 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
       const Father_opts = (attach_Father === true ? {} : attach_Father) as Record<string, unknown>;
       const Father_sel = Father_opts.select as Record<string, boolean> | undefined;
       const Father_keysToInject = Father_sel ? (["userId"] as string[]).filter((k) => !Father_sel![k]) : [];
+      const Father_take = Father_opts.take as number | undefined;
+      const Father_skip = Father_opts.skip as number | undefined;
+      const Father_cursor = Father_opts.cursor;
+      const Father_distinct = Father_opts.distinct;
       const Father_parentIds = [...new Set(records.map((r) => r.id))];
-      const Father_allRelated = await this.client.father.findMany(
-        {
-          ...Father_opts,
-          ...(Father_keysToInject.length > 0
-            ? { select: { ...Father_sel, ...Object.fromEntries(Father_keysToInject.map((k) => [k, true])) } }
-            : {}),
-          take: undefined,
-          skip: undefined,
-          where: { userId: { in: Father_parentIds } },
-        },
-        { tx }
-      );
-      const Father_take = attach_Father !== true ? (attach_Father as Prisma.FatherFindManyArgs).take : undefined;
-      const Father_skip = attach_Father !== true ? (attach_Father as Prisma.FatherFindManyArgs).skip : undefined;
       Father_hashMap = new Map<string, unknown[]>();
-      for (const related of Father_allRelated) {
-        const _r = related as Record<string, unknown>;
-        const key = JSON.stringify(_r["userId"]);
-        if (!Father_hashMap!.has(key)) Father_hashMap!.set(key, []);
-        const value =
-          Father_keysToInject.length > 0
-            ? Object.fromEntries(Object.entries(_r).filter(([k]) => !Father_keysToInject.includes(k)))
-            : _r;
-        Father_hashMap!.get(key)!.push(value as unknown);
-      }
-      if (Father_skip !== undefined || Father_take !== undefined) {
-        for (const [key, group] of Father_hashMap!) {
-          const start = Father_skip ?? 0;
-          const end = Father_take !== undefined ? start + Father_take : undefined;
-          Father_hashMap!.set(key, group.slice(start, end));
+      const Father_userWhere = Father_opts.where as Record<string, unknown> | undefined;
+      if (Father_cursor !== undefined || Father_distinct !== undefined) {
+        for (const parentId of Father_parentIds) {
+          const Father_perParentFkWhere = { userId: parentId };
+          const Father_perParentWhere = Father_userWhere
+            ? { AND: [Father_userWhere, Father_perParentFkWhere] }
+            : Father_perParentFkWhere;
+          const children = await this.client.father.findMany(
+            {
+              ...Father_opts,
+              ...(Father_keysToInject.length > 0
+                ? { select: { ...Father_sel, ...Object.fromEntries(Father_keysToInject.map((k) => [k, true])) } }
+                : {}),
+              where: Father_perParentWhere,
+            },
+            { tx }
+          );
+          const stripped = children.map((c) => {
+            const _r = c as Record<string, unknown>;
+            return Father_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !Father_keysToInject.includes(k)))
+              : _r;
+          });
+          Father_hashMap!.set(JSON.stringify(parentId), stripped as unknown[]);
+        }
+      } else {
+        const Father_fkWhere = { userId: { in: Father_parentIds } };
+        const Father_where = Father_userWhere ? { AND: [Father_userWhere, Father_fkWhere] } : Father_fkWhere;
+        const Father_allRelated = await this.client.father.findMany(
+          {
+            ...Father_opts,
+            ...(Father_keysToInject.length > 0
+              ? { select: { ...Father_sel, ...Object.fromEntries(Father_keysToInject.map((k) => [k, true])) } }
+              : {}),
+            take: undefined,
+            skip: undefined,
+            where: Father_where,
+          },
+          { tx }
+        );
+        for (const related of Father_allRelated) {
+          const _r = related as Record<string, unknown>;
+          const key = JSON.stringify(_r["userId"]);
+          if (!Father_hashMap!.has(key)) Father_hashMap!.set(key, []);
+          const value =
+            Father_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !Father_keysToInject.includes(k)))
+              : _r;
+          Father_hashMap!.get(key)!.push(value as unknown);
+        }
+        if (Father_skip !== undefined || Father_take !== undefined) {
+          for (const [key, group] of Father_hashMap!) {
+            let sliced = group;
+            if (Father_skip !== undefined) sliced = sliced.slice(Father_skip);
+            if (Father_take !== undefined)
+              sliced = Father_take < 0 ? sliced.slice(Father_take) : sliced.slice(0, Father_take);
+            Father_hashMap!.set(key, sliced);
+          }
         }
       }
     }
@@ -728,37 +863,70 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
       const Mother_opts = (attach_Mother === true ? {} : attach_Mother) as Record<string, unknown>;
       const Mother_sel = Mother_opts.select as Record<string, boolean> | undefined;
       const Mother_keysToInject = Mother_sel ? (["userId"] as string[]).filter((k) => !Mother_sel![k]) : [];
+      const Mother_take = Mother_opts.take as number | undefined;
+      const Mother_skip = Mother_opts.skip as number | undefined;
+      const Mother_cursor = Mother_opts.cursor;
+      const Mother_distinct = Mother_opts.distinct;
       const Mother_parentIds = [...new Set(records.map((r) => r.id))];
-      const Mother_allRelated = await this.client.mother.findMany(
-        {
-          ...Mother_opts,
-          ...(Mother_keysToInject.length > 0
-            ? { select: { ...Mother_sel, ...Object.fromEntries(Mother_keysToInject.map((k) => [k, true])) } }
-            : {}),
-          take: undefined,
-          skip: undefined,
-          where: { userId: { in: Mother_parentIds } },
-        },
-        { tx }
-      );
-      const Mother_take = attach_Mother !== true ? (attach_Mother as Prisma.MotherFindManyArgs).take : undefined;
-      const Mother_skip = attach_Mother !== true ? (attach_Mother as Prisma.MotherFindManyArgs).skip : undefined;
       Mother_hashMap = new Map<string, unknown[]>();
-      for (const related of Mother_allRelated) {
-        const _r = related as Record<string, unknown>;
-        const key = JSON.stringify(_r["userId"]);
-        if (!Mother_hashMap!.has(key)) Mother_hashMap!.set(key, []);
-        const value =
-          Mother_keysToInject.length > 0
-            ? Object.fromEntries(Object.entries(_r).filter(([k]) => !Mother_keysToInject.includes(k)))
-            : _r;
-        Mother_hashMap!.get(key)!.push(value as unknown);
-      }
-      if (Mother_skip !== undefined || Mother_take !== undefined) {
-        for (const [key, group] of Mother_hashMap!) {
-          const start = Mother_skip ?? 0;
-          const end = Mother_take !== undefined ? start + Mother_take : undefined;
-          Mother_hashMap!.set(key, group.slice(start, end));
+      const Mother_userWhere = Mother_opts.where as Record<string, unknown> | undefined;
+      if (Mother_cursor !== undefined || Mother_distinct !== undefined) {
+        for (const parentId of Mother_parentIds) {
+          const Mother_perParentFkWhere = { userId: parentId };
+          const Mother_perParentWhere = Mother_userWhere
+            ? { AND: [Mother_userWhere, Mother_perParentFkWhere] }
+            : Mother_perParentFkWhere;
+          const children = await this.client.mother.findMany(
+            {
+              ...Mother_opts,
+              ...(Mother_keysToInject.length > 0
+                ? { select: { ...Mother_sel, ...Object.fromEntries(Mother_keysToInject.map((k) => [k, true])) } }
+                : {}),
+              where: Mother_perParentWhere,
+            },
+            { tx }
+          );
+          const stripped = children.map((c) => {
+            const _r = c as Record<string, unknown>;
+            return Mother_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !Mother_keysToInject.includes(k)))
+              : _r;
+          });
+          Mother_hashMap!.set(JSON.stringify(parentId), stripped as unknown[]);
+        }
+      } else {
+        const Mother_fkWhere = { userId: { in: Mother_parentIds } };
+        const Mother_where = Mother_userWhere ? { AND: [Mother_userWhere, Mother_fkWhere] } : Mother_fkWhere;
+        const Mother_allRelated = await this.client.mother.findMany(
+          {
+            ...Mother_opts,
+            ...(Mother_keysToInject.length > 0
+              ? { select: { ...Mother_sel, ...Object.fromEntries(Mother_keysToInject.map((k) => [k, true])) } }
+              : {}),
+            take: undefined,
+            skip: undefined,
+            where: Mother_where,
+          },
+          { tx }
+        );
+        for (const related of Mother_allRelated) {
+          const _r = related as Record<string, unknown>;
+          const key = JSON.stringify(_r["userId"]);
+          if (!Mother_hashMap!.has(key)) Mother_hashMap!.set(key, []);
+          const value =
+            Mother_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !Mother_keysToInject.includes(k)))
+              : _r;
+          Mother_hashMap!.get(key)!.push(value as unknown);
+        }
+        if (Mother_skip !== undefined || Mother_take !== undefined) {
+          for (const [key, group] of Mother_hashMap!) {
+            let sliced = group;
+            if (Mother_skip !== undefined) sliced = sliced.slice(Mother_skip);
+            if (Mother_take !== undefined)
+              sliced = Mother_take < 0 ? sliced.slice(Mother_take) : sliced.slice(0, Mother_take);
+            Mother_hashMap!.set(key, sliced);
+          }
         }
       }
     }
@@ -768,37 +936,70 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
       const groups_opts = (attach_groups === true ? {} : attach_groups) as Record<string, unknown>;
       const groups_sel = groups_opts.select as Record<string, boolean> | undefined;
       const groups_keysToInject = groups_sel ? (["userId"] as string[]).filter((k) => !groups_sel![k]) : [];
+      const groups_take = groups_opts.take as number | undefined;
+      const groups_skip = groups_opts.skip as number | undefined;
+      const groups_cursor = groups_opts.cursor;
+      const groups_distinct = groups_opts.distinct;
       const groups_parentIds = [...new Set(records.map((r) => r.id))];
-      const groups_allRelated = await this.client.userGroup.findMany(
-        {
-          ...groups_opts,
-          ...(groups_keysToInject.length > 0
-            ? { select: { ...groups_sel, ...Object.fromEntries(groups_keysToInject.map((k) => [k, true])) } }
-            : {}),
-          take: undefined,
-          skip: undefined,
-          where: { userId: { in: groups_parentIds } },
-        },
-        { tx }
-      );
-      const groups_take = attach_groups !== true ? (attach_groups as Prisma.UserGroupFindManyArgs).take : undefined;
-      const groups_skip = attach_groups !== true ? (attach_groups as Prisma.UserGroupFindManyArgs).skip : undefined;
       groups_hashMap = new Map<string, unknown[]>();
-      for (const related of groups_allRelated) {
-        const _r = related as Record<string, unknown>;
-        const key = JSON.stringify(_r["userId"]);
-        if (!groups_hashMap!.has(key)) groups_hashMap!.set(key, []);
-        const value =
-          groups_keysToInject.length > 0
-            ? Object.fromEntries(Object.entries(_r).filter(([k]) => !groups_keysToInject.includes(k)))
-            : _r;
-        groups_hashMap!.get(key)!.push(value as unknown);
-      }
-      if (groups_skip !== undefined || groups_take !== undefined) {
-        for (const [key, group] of groups_hashMap!) {
-          const start = groups_skip ?? 0;
-          const end = groups_take !== undefined ? start + groups_take : undefined;
-          groups_hashMap!.set(key, group.slice(start, end));
+      const groups_userWhere = groups_opts.where as Record<string, unknown> | undefined;
+      if (groups_cursor !== undefined || groups_distinct !== undefined) {
+        for (const parentId of groups_parentIds) {
+          const groups_perParentFkWhere = { userId: parentId };
+          const groups_perParentWhere = groups_userWhere
+            ? { AND: [groups_userWhere, groups_perParentFkWhere] }
+            : groups_perParentFkWhere;
+          const children = await this.client.userGroup.findMany(
+            {
+              ...groups_opts,
+              ...(groups_keysToInject.length > 0
+                ? { select: { ...groups_sel, ...Object.fromEntries(groups_keysToInject.map((k) => [k, true])) } }
+                : {}),
+              where: groups_perParentWhere,
+            },
+            { tx }
+          );
+          const stripped = children.map((c) => {
+            const _r = c as Record<string, unknown>;
+            return groups_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !groups_keysToInject.includes(k)))
+              : _r;
+          });
+          groups_hashMap!.set(JSON.stringify(parentId), stripped as unknown[]);
+        }
+      } else {
+        const groups_fkWhere = { userId: { in: groups_parentIds } };
+        const groups_where = groups_userWhere ? { AND: [groups_userWhere, groups_fkWhere] } : groups_fkWhere;
+        const groups_allRelated = await this.client.userGroup.findMany(
+          {
+            ...groups_opts,
+            ...(groups_keysToInject.length > 0
+              ? { select: { ...groups_sel, ...Object.fromEntries(groups_keysToInject.map((k) => [k, true])) } }
+              : {}),
+            take: undefined,
+            skip: undefined,
+            where: groups_where,
+          },
+          { tx }
+        );
+        for (const related of groups_allRelated) {
+          const _r = related as Record<string, unknown>;
+          const key = JSON.stringify(_r["userId"]);
+          if (!groups_hashMap!.has(key)) groups_hashMap!.set(key, []);
+          const value =
+            groups_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !groups_keysToInject.includes(k)))
+              : _r;
+          groups_hashMap!.get(key)!.push(value as unknown);
+        }
+        if (groups_skip !== undefined || groups_take !== undefined) {
+          for (const [key, group] of groups_hashMap!) {
+            let sliced = group;
+            if (groups_skip !== undefined) sliced = sliced.slice(groups_skip);
+            if (groups_take !== undefined)
+              sliced = groups_take < 0 ? sliced.slice(groups_take) : sliced.slice(0, groups_take);
+            groups_hashMap!.set(key, sliced);
+          }
         }
       }
     }
@@ -808,37 +1009,70 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
       const todos_opts = (attach_todos === true ? {} : attach_todos) as Record<string, unknown>;
       const todos_sel = todos_opts.select as Record<string, boolean> | undefined;
       const todos_keysToInject = todos_sel ? (["userId"] as string[]).filter((k) => !todos_sel![k]) : [];
+      const todos_take = todos_opts.take as number | undefined;
+      const todos_skip = todos_opts.skip as number | undefined;
+      const todos_cursor = todos_opts.cursor;
+      const todos_distinct = todos_opts.distinct;
       const todos_parentIds = [...new Set(records.map((r) => r.id))];
-      const todos_allRelated = await this.client.todo.findMany(
-        {
-          ...todos_opts,
-          ...(todos_keysToInject.length > 0
-            ? { select: { ...todos_sel, ...Object.fromEntries(todos_keysToInject.map((k) => [k, true])) } }
-            : {}),
-          take: undefined,
-          skip: undefined,
-          where: { userId: { in: todos_parentIds } },
-        },
-        { tx }
-      );
-      const todos_take = attach_todos !== true ? (attach_todos as Prisma.TodoFindManyArgs).take : undefined;
-      const todos_skip = attach_todos !== true ? (attach_todos as Prisma.TodoFindManyArgs).skip : undefined;
       todos_hashMap = new Map<string, unknown[]>();
-      for (const related of todos_allRelated) {
-        const _r = related as Record<string, unknown>;
-        const key = JSON.stringify(_r["userId"]);
-        if (!todos_hashMap!.has(key)) todos_hashMap!.set(key, []);
-        const value =
-          todos_keysToInject.length > 0
-            ? Object.fromEntries(Object.entries(_r).filter(([k]) => !todos_keysToInject.includes(k)))
-            : _r;
-        todos_hashMap!.get(key)!.push(value as unknown);
-      }
-      if (todos_skip !== undefined || todos_take !== undefined) {
-        for (const [key, group] of todos_hashMap!) {
-          const start = todos_skip ?? 0;
-          const end = todos_take !== undefined ? start + todos_take : undefined;
-          todos_hashMap!.set(key, group.slice(start, end));
+      const todos_userWhere = todos_opts.where as Record<string, unknown> | undefined;
+      if (todos_cursor !== undefined || todos_distinct !== undefined) {
+        for (const parentId of todos_parentIds) {
+          const todos_perParentFkWhere = { userId: parentId };
+          const todos_perParentWhere = todos_userWhere
+            ? { AND: [todos_userWhere, todos_perParentFkWhere] }
+            : todos_perParentFkWhere;
+          const children = await this.client.todo.findMany(
+            {
+              ...todos_opts,
+              ...(todos_keysToInject.length > 0
+                ? { select: { ...todos_sel, ...Object.fromEntries(todos_keysToInject.map((k) => [k, true])) } }
+                : {}),
+              where: todos_perParentWhere,
+            },
+            { tx }
+          );
+          const stripped = children.map((c) => {
+            const _r = c as Record<string, unknown>;
+            return todos_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !todos_keysToInject.includes(k)))
+              : _r;
+          });
+          todos_hashMap!.set(JSON.stringify(parentId), stripped as unknown[]);
+        }
+      } else {
+        const todos_fkWhere = { userId: { in: todos_parentIds } };
+        const todos_where = todos_userWhere ? { AND: [todos_userWhere, todos_fkWhere] } : todos_fkWhere;
+        const todos_allRelated = await this.client.todo.findMany(
+          {
+            ...todos_opts,
+            ...(todos_keysToInject.length > 0
+              ? { select: { ...todos_sel, ...Object.fromEntries(todos_keysToInject.map((k) => [k, true])) } }
+              : {}),
+            take: undefined,
+            skip: undefined,
+            where: todos_where,
+          },
+          { tx }
+        );
+        for (const related of todos_allRelated) {
+          const _r = related as Record<string, unknown>;
+          const key = JSON.stringify(_r["userId"]);
+          if (!todos_hashMap!.has(key)) todos_hashMap!.set(key, []);
+          const value =
+            todos_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !todos_keysToInject.includes(k)))
+              : _r;
+          todos_hashMap!.get(key)!.push(value as unknown);
+        }
+        if (todos_skip !== undefined || todos_take !== undefined) {
+          for (const [key, group] of todos_hashMap!) {
+            let sliced = group;
+            if (todos_skip !== undefined) sliced = sliced.slice(todos_skip);
+            if (todos_take !== undefined)
+              sliced = todos_take < 0 ? sliced.slice(todos_take) : sliced.slice(0, todos_take);
+            todos_hashMap!.set(key, sliced);
+          }
         }
       }
     }
@@ -3545,39 +3779,74 @@ class GroupIDBClass extends BaseIDBModelClass<"Group"> {
       const userGroups_keysToInject = userGroups_sel
         ? (["groupId"] as string[]).filter((k) => !userGroups_sel![k])
         : [];
+      const userGroups_take = userGroups_opts.take as number | undefined;
+      const userGroups_skip = userGroups_opts.skip as number | undefined;
+      const userGroups_cursor = userGroups_opts.cursor;
+      const userGroups_distinct = userGroups_opts.distinct;
       const userGroups_parentIds = [...new Set(records.map((r) => r.id))];
-      const userGroups_allRelated = await this.client.userGroup.findMany(
-        {
-          ...userGroups_opts,
-          ...(userGroups_keysToInject.length > 0
-            ? { select: { ...userGroups_sel, ...Object.fromEntries(userGroups_keysToInject.map((k) => [k, true])) } }
-            : {}),
-          take: undefined,
-          skip: undefined,
-          where: { groupId: { in: userGroups_parentIds } },
-        },
-        { tx }
-      );
-      const userGroups_take =
-        attach_userGroups !== true ? (attach_userGroups as Prisma.UserGroupFindManyArgs).take : undefined;
-      const userGroups_skip =
-        attach_userGroups !== true ? (attach_userGroups as Prisma.UserGroupFindManyArgs).skip : undefined;
       userGroups_hashMap = new Map<string, unknown[]>();
-      for (const related of userGroups_allRelated) {
-        const _r = related as Record<string, unknown>;
-        const key = JSON.stringify(_r["groupId"]);
-        if (!userGroups_hashMap!.has(key)) userGroups_hashMap!.set(key, []);
-        const value =
-          userGroups_keysToInject.length > 0
-            ? Object.fromEntries(Object.entries(_r).filter(([k]) => !userGroups_keysToInject.includes(k)))
-            : _r;
-        userGroups_hashMap!.get(key)!.push(value as unknown);
-      }
-      if (userGroups_skip !== undefined || userGroups_take !== undefined) {
-        for (const [key, group] of userGroups_hashMap!) {
-          const start = userGroups_skip ?? 0;
-          const end = userGroups_take !== undefined ? start + userGroups_take : undefined;
-          userGroups_hashMap!.set(key, group.slice(start, end));
+      const userGroups_userWhere = userGroups_opts.where as Record<string, unknown> | undefined;
+      if (userGroups_cursor !== undefined || userGroups_distinct !== undefined) {
+        for (const parentId of userGroups_parentIds) {
+          const userGroups_perParentFkWhere = { groupId: parentId };
+          const userGroups_perParentWhere = userGroups_userWhere
+            ? { AND: [userGroups_userWhere, userGroups_perParentFkWhere] }
+            : userGroups_perParentFkWhere;
+          const children = await this.client.userGroup.findMany(
+            {
+              ...userGroups_opts,
+              ...(userGroups_keysToInject.length > 0
+                ? {
+                    select: { ...userGroups_sel, ...Object.fromEntries(userGroups_keysToInject.map((k) => [k, true])) },
+                  }
+                : {}),
+              where: userGroups_perParentWhere,
+            },
+            { tx }
+          );
+          const stripped = children.map((c) => {
+            const _r = c as Record<string, unknown>;
+            return userGroups_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !userGroups_keysToInject.includes(k)))
+              : _r;
+          });
+          userGroups_hashMap!.set(JSON.stringify(parentId), stripped as unknown[]);
+        }
+      } else {
+        const userGroups_fkWhere = { groupId: { in: userGroups_parentIds } };
+        const userGroups_where = userGroups_userWhere
+          ? { AND: [userGroups_userWhere, userGroups_fkWhere] }
+          : userGroups_fkWhere;
+        const userGroups_allRelated = await this.client.userGroup.findMany(
+          {
+            ...userGroups_opts,
+            ...(userGroups_keysToInject.length > 0
+              ? { select: { ...userGroups_sel, ...Object.fromEntries(userGroups_keysToInject.map((k) => [k, true])) } }
+              : {}),
+            take: undefined,
+            skip: undefined,
+            where: userGroups_where,
+          },
+          { tx }
+        );
+        for (const related of userGroups_allRelated) {
+          const _r = related as Record<string, unknown>;
+          const key = JSON.stringify(_r["groupId"]);
+          if (!userGroups_hashMap!.has(key)) userGroups_hashMap!.set(key, []);
+          const value =
+            userGroups_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !userGroups_keysToInject.includes(k)))
+              : _r;
+          userGroups_hashMap!.get(key)!.push(value as unknown);
+        }
+        if (userGroups_skip !== undefined || userGroups_take !== undefined) {
+          for (const [key, group] of userGroups_hashMap!) {
+            let sliced = group;
+            if (userGroups_skip !== undefined) sliced = sliced.slice(userGroups_skip);
+            if (userGroups_take !== undefined)
+              sliced = userGroups_take < 0 ? sliced.slice(userGroups_take) : sliced.slice(0, userGroups_take);
+            userGroups_hashMap!.set(key, sliced);
+          }
         }
       }
     }
@@ -4481,13 +4750,16 @@ class ProfileIDBClass extends BaseIDBModelClass<"Profile"> {
       const user_sel = user_opts.select as Record<string, boolean> | undefined;
       const user_keysToInject = user_sel ? (["id"] as string[]).filter((k) => !user_sel![k]) : [];
       const user_fkValues = [...new Set(records.map((r) => r.userId).filter((v) => v !== null && v !== undefined))];
+      const user_userWhere = user_opts.where as Record<string, unknown> | undefined;
+      const user_fkWhere = { id: { in: user_fkValues } };
+      const user_where = user_userWhere ? { AND: [user_userWhere, user_fkWhere] } : user_fkWhere;
       const user_related = await this.client.user.findMany(
         {
           ...user_opts,
           ...(user_keysToInject.length > 0
             ? { select: { ...user_sel, ...Object.fromEntries(user_keysToInject.map((k) => [k, true])) } }
             : {}),
-          where: { id: { in: user_fkValues } },
+          where: user_where,
         },
         { tx }
       );
@@ -5367,13 +5639,16 @@ class PostIDBClass extends BaseIDBModelClass<"Post"> {
       const author_sel = author_opts.select as Record<string, boolean> | undefined;
       const author_keysToInject = author_sel ? (["id"] as string[]).filter((k) => !author_sel![k]) : [];
       const author_fkValues = [...new Set(records.map((r) => r.authorId).filter((v) => v !== null && v !== undefined))];
+      const author_userWhere = author_opts.where as Record<string, unknown> | undefined;
+      const author_fkWhere = { id: { in: author_fkValues } };
+      const author_where = author_userWhere ? { AND: [author_userWhere, author_fkWhere] } : author_fkWhere;
       const author_related = await this.client.user.findMany(
         {
           ...author_opts,
           ...(author_keysToInject.length > 0
             ? { select: { ...author_sel, ...Object.fromEntries(author_keysToInject.map((k) => [k, true])) } }
             : {}),
-          where: { id: { in: author_fkValues } },
+          where: author_where,
         },
         { tx }
       );
@@ -5395,37 +5670,70 @@ class PostIDBClass extends BaseIDBModelClass<"Post"> {
       const comments_opts = (attach_comments === true ? {} : attach_comments) as Record<string, unknown>;
       const comments_sel = comments_opts.select as Record<string, boolean> | undefined;
       const comments_keysToInject = comments_sel ? (["postId"] as string[]).filter((k) => !comments_sel![k]) : [];
+      const comments_take = comments_opts.take as number | undefined;
+      const comments_skip = comments_opts.skip as number | undefined;
+      const comments_cursor = comments_opts.cursor;
+      const comments_distinct = comments_opts.distinct;
       const comments_parentIds = [...new Set(records.map((r) => r.id))];
-      const comments_allRelated = await this.client.comment.findMany(
-        {
-          ...comments_opts,
-          ...(comments_keysToInject.length > 0
-            ? { select: { ...comments_sel, ...Object.fromEntries(comments_keysToInject.map((k) => [k, true])) } }
-            : {}),
-          take: undefined,
-          skip: undefined,
-          where: { postId: { in: comments_parentIds } },
-        },
-        { tx }
-      );
-      const comments_take = attach_comments !== true ? (attach_comments as Prisma.CommentFindManyArgs).take : undefined;
-      const comments_skip = attach_comments !== true ? (attach_comments as Prisma.CommentFindManyArgs).skip : undefined;
       comments_hashMap = new Map<string, unknown[]>();
-      for (const related of comments_allRelated) {
-        const _r = related as Record<string, unknown>;
-        const key = JSON.stringify(_r["postId"]);
-        if (!comments_hashMap!.has(key)) comments_hashMap!.set(key, []);
-        const value =
-          comments_keysToInject.length > 0
-            ? Object.fromEntries(Object.entries(_r).filter(([k]) => !comments_keysToInject.includes(k)))
-            : _r;
-        comments_hashMap!.get(key)!.push(value as unknown);
-      }
-      if (comments_skip !== undefined || comments_take !== undefined) {
-        for (const [key, group] of comments_hashMap!) {
-          const start = comments_skip ?? 0;
-          const end = comments_take !== undefined ? start + comments_take : undefined;
-          comments_hashMap!.set(key, group.slice(start, end));
+      const comments_userWhere = comments_opts.where as Record<string, unknown> | undefined;
+      if (comments_cursor !== undefined || comments_distinct !== undefined) {
+        for (const parentId of comments_parentIds) {
+          const comments_perParentFkWhere = { postId: parentId };
+          const comments_perParentWhere = comments_userWhere
+            ? { AND: [comments_userWhere, comments_perParentFkWhere] }
+            : comments_perParentFkWhere;
+          const children = await this.client.comment.findMany(
+            {
+              ...comments_opts,
+              ...(comments_keysToInject.length > 0
+                ? { select: { ...comments_sel, ...Object.fromEntries(comments_keysToInject.map((k) => [k, true])) } }
+                : {}),
+              where: comments_perParentWhere,
+            },
+            { tx }
+          );
+          const stripped = children.map((c) => {
+            const _r = c as Record<string, unknown>;
+            return comments_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !comments_keysToInject.includes(k)))
+              : _r;
+          });
+          comments_hashMap!.set(JSON.stringify(parentId), stripped as unknown[]);
+        }
+      } else {
+        const comments_fkWhere = { postId: { in: comments_parentIds } };
+        const comments_where = comments_userWhere ? { AND: [comments_userWhere, comments_fkWhere] } : comments_fkWhere;
+        const comments_allRelated = await this.client.comment.findMany(
+          {
+            ...comments_opts,
+            ...(comments_keysToInject.length > 0
+              ? { select: { ...comments_sel, ...Object.fromEntries(comments_keysToInject.map((k) => [k, true])) } }
+              : {}),
+            take: undefined,
+            skip: undefined,
+            where: comments_where,
+          },
+          { tx }
+        );
+        for (const related of comments_allRelated) {
+          const _r = related as Record<string, unknown>;
+          const key = JSON.stringify(_r["postId"]);
+          if (!comments_hashMap!.has(key)) comments_hashMap!.set(key, []);
+          const value =
+            comments_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !comments_keysToInject.includes(k)))
+              : _r;
+          comments_hashMap!.get(key)!.push(value as unknown);
+        }
+        if (comments_skip !== undefined || comments_take !== undefined) {
+          for (const [key, group] of comments_hashMap!) {
+            let sliced = group;
+            if (comments_skip !== undefined) sliced = sliced.slice(comments_skip);
+            if (comments_take !== undefined)
+              sliced = comments_take < 0 ? sliced.slice(comments_take) : sliced.slice(0, comments_take);
+            comments_hashMap!.set(key, sliced);
+          }
         }
       }
     }
@@ -6572,13 +6880,16 @@ class CommentIDBClass extends BaseIDBModelClass<"Comment"> {
       const post_sel = post_opts.select as Record<string, boolean> | undefined;
       const post_keysToInject = post_sel ? (["id"] as string[]).filter((k) => !post_sel![k]) : [];
       const post_fkValues = [...new Set(records.map((r) => r.postId).filter((v) => v !== null && v !== undefined))];
+      const post_userWhere = post_opts.where as Record<string, unknown> | undefined;
+      const post_fkWhere = { id: { in: post_fkValues } };
+      const post_where = post_userWhere ? { AND: [post_userWhere, post_fkWhere] } : post_fkWhere;
       const post_related = await this.client.post.findMany(
         {
           ...post_opts,
           ...(post_keysToInject.length > 0
             ? { select: { ...post_sel, ...Object.fromEntries(post_keysToInject.map((k) => [k, true])) } }
             : {}),
-          where: { id: { in: post_fkValues } },
+          where: post_where,
         },
         { tx }
       );
@@ -6601,13 +6912,16 @@ class CommentIDBClass extends BaseIDBModelClass<"Comment"> {
       const user_sel = user_opts.select as Record<string, boolean> | undefined;
       const user_keysToInject = user_sel ? (["id"] as string[]).filter((k) => !user_sel![k]) : [];
       const user_fkValues = [...new Set(records.map((r) => r.userId).filter((v) => v !== null && v !== undefined))];
+      const user_userWhere = user_opts.where as Record<string, unknown> | undefined;
+      const user_fkWhere = { id: { in: user_fkValues } };
+      const user_where = user_userWhere ? { AND: [user_userWhere, user_fkWhere] } : user_fkWhere;
       const user_related = await this.client.user.findMany(
         {
           ...user_opts,
           ...(user_keysToInject.length > 0
             ? { select: { ...user_sel, ...Object.fromEntries(user_keysToInject.map((k) => [k, true])) } }
             : {}),
-          where: { id: { in: user_fkValues } },
+          where: user_where,
         },
         { tx }
       );
@@ -7600,13 +7914,16 @@ class TodoIDBClass extends BaseIDBModelClass<"Todo"> {
       const user_sel = user_opts.select as Record<string, boolean> | undefined;
       const user_keysToInject = user_sel ? (["id"] as string[]).filter((k) => !user_sel![k]) : [];
       const user_fkValues = [...new Set(records.map((r) => r.userId).filter((v) => v !== null && v !== undefined))];
+      const user_userWhere = user_opts.where as Record<string, unknown> | undefined;
+      const user_fkWhere = { id: { in: user_fkValues } };
+      const user_where = user_userWhere ? { AND: [user_userWhere, user_fkWhere] } : user_fkWhere;
       const user_related = await this.client.user.findMany(
         {
           ...user_opts,
           ...(user_keysToInject.length > 0
             ? { select: { ...user_sel, ...Object.fromEntries(user_keysToInject.map((k) => [k, true])) } }
             : {}),
-          where: { id: { in: user_fkValues } },
+          where: user_where,
         },
         { tx }
       );
@@ -10440,13 +10757,16 @@ class ModelWithOptionalRelationToUniqueAttributesIDBClass extends BaseIDBModelCl
       const link_sel = link_opts.select as Record<string, boolean> | undefined;
       const link_keysToInject = link_sel ? (["id"] as string[]).filter((k) => !link_sel![k]) : [];
       const link_fkValues = [...new Set(records.map((r) => r.linkId).filter((v) => v !== null && v !== undefined))];
+      const link_userWhere = link_opts.where as Record<string, unknown> | undefined;
+      const link_fkWhere = { id: { in: link_fkValues } };
+      const link_where = link_userWhere ? { AND: [link_userWhere, link_fkWhere] } : link_fkWhere;
       const link_related = await this.client.modelWithUniqueAttributes.findMany(
         {
           ...link_opts,
           ...(link_keysToInject.length > 0
             ? { select: { ...link_sel, ...Object.fromEntries(link_keysToInject.map((k) => [k, true])) } }
             : {}),
-          where: { id: { in: link_fkValues } },
+          where: link_where,
         },
         { tx }
       );
@@ -11390,43 +11710,70 @@ class ModelWithUniqueAttributesIDBClass extends BaseIDBModelClass<"ModelWithUniq
       const links_opts = (attach_links === true ? {} : attach_links) as Record<string, unknown>;
       const links_sel = links_opts.select as Record<string, boolean> | undefined;
       const links_keysToInject = links_sel ? (["linkId"] as string[]).filter((k) => !links_sel![k]) : [];
+      const links_take = links_opts.take as number | undefined;
+      const links_skip = links_opts.skip as number | undefined;
+      const links_cursor = links_opts.cursor;
+      const links_distinct = links_opts.distinct;
       const links_parentIds = [...new Set(records.map((r) => r.id))];
-      const links_allRelated = await this.client.modelWithOptionalRelationToUniqueAttributes.findMany(
-        {
-          ...links_opts,
-          ...(links_keysToInject.length > 0
-            ? { select: { ...links_sel, ...Object.fromEntries(links_keysToInject.map((k) => [k, true])) } }
-            : {}),
-          take: undefined,
-          skip: undefined,
-          where: { linkId: { in: links_parentIds } },
-        },
-        { tx }
-      );
-      const links_take =
-        attach_links !== true
-          ? (attach_links as Prisma.ModelWithOptionalRelationToUniqueAttributesFindManyArgs).take
-          : undefined;
-      const links_skip =
-        attach_links !== true
-          ? (attach_links as Prisma.ModelWithOptionalRelationToUniqueAttributesFindManyArgs).skip
-          : undefined;
       links_hashMap = new Map<string, unknown[]>();
-      for (const related of links_allRelated) {
-        const _r = related as Record<string, unknown>;
-        const key = JSON.stringify(_r["linkId"]);
-        if (!links_hashMap!.has(key)) links_hashMap!.set(key, []);
-        const value =
-          links_keysToInject.length > 0
-            ? Object.fromEntries(Object.entries(_r).filter(([k]) => !links_keysToInject.includes(k)))
-            : _r;
-        links_hashMap!.get(key)!.push(value as unknown);
-      }
-      if (links_skip !== undefined || links_take !== undefined) {
-        for (const [key, group] of links_hashMap!) {
-          const start = links_skip ?? 0;
-          const end = links_take !== undefined ? start + links_take : undefined;
-          links_hashMap!.set(key, group.slice(start, end));
+      const links_userWhere = links_opts.where as Record<string, unknown> | undefined;
+      if (links_cursor !== undefined || links_distinct !== undefined) {
+        for (const parentId of links_parentIds) {
+          const links_perParentFkWhere = { linkId: parentId };
+          const links_perParentWhere = links_userWhere
+            ? { AND: [links_userWhere, links_perParentFkWhere] }
+            : links_perParentFkWhere;
+          const children = await this.client.modelWithOptionalRelationToUniqueAttributes.findMany(
+            {
+              ...links_opts,
+              ...(links_keysToInject.length > 0
+                ? { select: { ...links_sel, ...Object.fromEntries(links_keysToInject.map((k) => [k, true])) } }
+                : {}),
+              where: links_perParentWhere,
+            },
+            { tx }
+          );
+          const stripped = children.map((c) => {
+            const _r = c as Record<string, unknown>;
+            return links_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !links_keysToInject.includes(k)))
+              : _r;
+          });
+          links_hashMap!.set(JSON.stringify(parentId), stripped as unknown[]);
+        }
+      } else {
+        const links_fkWhere = { linkId: { in: links_parentIds } };
+        const links_where = links_userWhere ? { AND: [links_userWhere, links_fkWhere] } : links_fkWhere;
+        const links_allRelated = await this.client.modelWithOptionalRelationToUniqueAttributes.findMany(
+          {
+            ...links_opts,
+            ...(links_keysToInject.length > 0
+              ? { select: { ...links_sel, ...Object.fromEntries(links_keysToInject.map((k) => [k, true])) } }
+              : {}),
+            take: undefined,
+            skip: undefined,
+            where: links_where,
+          },
+          { tx }
+        );
+        for (const related of links_allRelated) {
+          const _r = related as Record<string, unknown>;
+          const key = JSON.stringify(_r["linkId"]);
+          if (!links_hashMap!.has(key)) links_hashMap!.set(key, []);
+          const value =
+            links_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !links_keysToInject.includes(k)))
+              : _r;
+          links_hashMap!.get(key)!.push(value as unknown);
+        }
+        if (links_skip !== undefined || links_take !== undefined) {
+          for (const [key, group] of links_hashMap!) {
+            let sliced = group;
+            if (links_skip !== undefined) sliced = sliced.slice(links_skip);
+            if (links_take !== undefined)
+              sliced = links_take < 0 ? sliced.slice(links_take) : sliced.slice(0, links_take);
+            links_hashMap!.set(key, sliced);
+          }
         }
       }
     }
@@ -12425,13 +12772,16 @@ class UserGroupIDBClass extends BaseIDBModelClass<"UserGroup"> {
       const group_sel = group_opts.select as Record<string, boolean> | undefined;
       const group_keysToInject = group_sel ? (["id"] as string[]).filter((k) => !group_sel![k]) : [];
       const group_fkValues = [...new Set(records.map((r) => r.groupId).filter((v) => v !== null && v !== undefined))];
+      const group_userWhere = group_opts.where as Record<string, unknown> | undefined;
+      const group_fkWhere = { id: { in: group_fkValues } };
+      const group_where = group_userWhere ? { AND: [group_userWhere, group_fkWhere] } : group_fkWhere;
       const group_related = await this.client.group.findMany(
         {
           ...group_opts,
           ...(group_keysToInject.length > 0
             ? { select: { ...group_sel, ...Object.fromEntries(group_keysToInject.map((k) => [k, true])) } }
             : {}),
-          where: { id: { in: group_fkValues } },
+          where: group_where,
         },
         { tx }
       );
@@ -12454,13 +12804,16 @@ class UserGroupIDBClass extends BaseIDBModelClass<"UserGroup"> {
       const user_sel = user_opts.select as Record<string, boolean> | undefined;
       const user_keysToInject = user_sel ? (["id"] as string[]).filter((k) => !user_sel![k]) : [];
       const user_fkValues = [...new Set(records.map((r) => r.userId).filter((v) => v !== null && v !== undefined))];
+      const user_userWhere = user_opts.where as Record<string, unknown> | undefined;
+      const user_fkWhere = { id: { in: user_fkValues } };
+      const user_where = user_userWhere ? { AND: [user_userWhere, user_fkWhere] } : user_fkWhere;
       const user_related = await this.client.user.findMany(
         {
           ...user_opts,
           ...(user_keysToInject.length > 0
             ? { select: { ...user_sel, ...Object.fromEntries(user_keysToInject.map((k) => [k, true])) } }
             : {}),
-          where: { id: { in: user_fkValues } },
+          where: user_where,
         },
         { tx }
       );
@@ -13556,38 +13909,74 @@ class FatherIDBClass extends BaseIDBModelClass<"Father"> {
       const children_keysToInject = children_sel
         ? (["fatherLastName", "fatherFirstName"] as string[]).filter((k) => !children_sel![k])
         : [];
+      const children_take = children_opts.take as number | undefined;
+      const children_skip = children_opts.skip as number | undefined;
+      const children_cursor = children_opts.cursor;
+      const children_distinct = children_opts.distinct;
       const children_pk0_values = [...new Set(records.map((r) => r.lastName))];
       const children_pk1_values = [...new Set(records.map((r) => r.firstName))];
-      const children_allRelated = await this.client.child.findMany(
-        {
-          ...children_opts,
-          ...(children_keysToInject.length > 0
-            ? { select: { ...children_sel, ...Object.fromEntries(children_keysToInject.map((k) => [k, true])) } }
-            : {}),
-          take: undefined,
-          skip: undefined,
-          where: { fatherLastName: { in: children_pk0_values }, fatherFirstName: { in: children_pk1_values } },
-        },
-        { tx }
-      );
-      const children_take = attach_children !== true ? (attach_children as Prisma.ChildFindManyArgs).take : undefined;
-      const children_skip = attach_children !== true ? (attach_children as Prisma.ChildFindManyArgs).skip : undefined;
       children_hashMap = new Map<string, unknown[]>();
-      for (const related of children_allRelated) {
-        const _r = related as Record<string, unknown>;
-        const key = JSON.stringify([_r["fatherLastName"], _r["fatherFirstName"]]);
-        if (!children_hashMap!.has(key)) children_hashMap!.set(key, []);
-        const value =
-          children_keysToInject.length > 0
-            ? Object.fromEntries(Object.entries(_r).filter(([k]) => !children_keysToInject.includes(k)))
-            : _r;
-        children_hashMap!.get(key)!.push(value as unknown);
-      }
-      if (children_skip !== undefined || children_take !== undefined) {
-        for (const [key, group] of children_hashMap!) {
-          const start = children_skip ?? 0;
-          const end = children_take !== undefined ? start + children_take : undefined;
-          children_hashMap!.set(key, group.slice(start, end));
+      const children_userWhere = children_opts.where as Record<string, unknown> | undefined;
+      if (children_cursor !== undefined || children_distinct !== undefined) {
+        for (const parent of records) {
+          const children_perParentFkWhere = { fatherLastName: parent.lastName, fatherFirstName: parent.firstName };
+          const children_perParentWhere = children_userWhere
+            ? { AND: [children_userWhere, children_perParentFkWhere] }
+            : children_perParentFkWhere;
+          const children = await this.client.child.findMany(
+            {
+              ...children_opts,
+              ...(children_keysToInject.length > 0
+                ? { select: { ...children_sel, ...Object.fromEntries(children_keysToInject.map((k) => [k, true])) } }
+                : {}),
+              where: children_perParentWhere,
+            },
+            { tx }
+          );
+          const stripped = children.map((c) => {
+            const _r = c as Record<string, unknown>;
+            return children_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !children_keysToInject.includes(k)))
+              : _r;
+          });
+          children_hashMap!.set(JSON.stringify([parent.lastName, parent.firstName]), stripped as unknown[]);
+        }
+      } else {
+        const children_fkWhere = {
+          fatherLastName: { in: children_pk0_values },
+          fatherFirstName: { in: children_pk1_values },
+        };
+        const children_where = children_userWhere ? { AND: [children_userWhere, children_fkWhere] } : children_fkWhere;
+        const children_allRelated = await this.client.child.findMany(
+          {
+            ...children_opts,
+            ...(children_keysToInject.length > 0
+              ? { select: { ...children_sel, ...Object.fromEntries(children_keysToInject.map((k) => [k, true])) } }
+              : {}),
+            take: undefined,
+            skip: undefined,
+            where: children_where,
+          },
+          { tx }
+        );
+        for (const related of children_allRelated) {
+          const _r = related as Record<string, unknown>;
+          const key = JSON.stringify([_r["fatherLastName"], _r["fatherFirstName"]]);
+          if (!children_hashMap!.has(key)) children_hashMap!.set(key, []);
+          const value =
+            children_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !children_keysToInject.includes(k)))
+              : _r;
+          children_hashMap!.get(key)!.push(value as unknown);
+        }
+        if (children_skip !== undefined || children_take !== undefined) {
+          for (const [key, group] of children_hashMap!) {
+            let sliced = group;
+            if (children_skip !== undefined) sliced = sliced.slice(children_skip);
+            if (children_take !== undefined)
+              sliced = children_take < 0 ? sliced.slice(children_take) : sliced.slice(0, children_take);
+            children_hashMap!.set(key, sliced);
+          }
         }
       }
     }
@@ -13603,13 +13992,16 @@ class FatherIDBClass extends BaseIDBModelClass<"Father"> {
       const wife_pk1_values = [
         ...new Set(records.map((r) => r.motherLastName).filter((v) => v !== null && v !== undefined)),
       ];
+      const wife_userWhere = wife_opts.where as Record<string, unknown> | undefined;
+      const wife_fkWhere = { firstName: { in: wife_pk0_values }, lastName: { in: wife_pk1_values } };
+      const wife_where = wife_userWhere ? { AND: [wife_userWhere, wife_fkWhere] } : wife_fkWhere;
       const wife_related = await this.client.mother.findMany(
         {
           ...wife_opts,
           ...(wife_keysToInject.length > 0
             ? { select: { ...wife_sel, ...Object.fromEntries(wife_keysToInject.map((k) => [k, true])) } }
             : {}),
-          where: { firstName: { in: wife_pk0_values }, lastName: { in: wife_pk1_values } },
+          where: wife_where,
         },
         { tx }
       );
@@ -13632,13 +14024,16 @@ class FatherIDBClass extends BaseIDBModelClass<"Father"> {
       const user_sel = user_opts.select as Record<string, boolean> | undefined;
       const user_keysToInject = user_sel ? (["id"] as string[]).filter((k) => !user_sel![k]) : [];
       const user_fkValues = [...new Set(records.map((r) => r.userId).filter((v) => v !== null && v !== undefined))];
+      const user_userWhere = user_opts.where as Record<string, unknown> | undefined;
+      const user_fkWhere = { id: { in: user_fkValues } };
+      const user_where = user_userWhere ? { AND: [user_userWhere, user_fkWhere] } : user_fkWhere;
       const user_related = await this.client.user.findMany(
         {
           ...user_opts,
           ...(user_keysToInject.length > 0
             ? { select: { ...user_sel, ...Object.fromEntries(user_keysToInject.map((k) => [k, true])) } }
             : {}),
-          where: { id: { in: user_fkValues } },
+          where: user_where,
         },
         { tx }
       );
@@ -15108,38 +15503,74 @@ class MotherIDBClass extends BaseIDBModelClass<"Mother"> {
       const children_keysToInject = children_sel
         ? (["motherFirstName", "motherLastName"] as string[]).filter((k) => !children_sel![k])
         : [];
+      const children_take = children_opts.take as number | undefined;
+      const children_skip = children_opts.skip as number | undefined;
+      const children_cursor = children_opts.cursor;
+      const children_distinct = children_opts.distinct;
       const children_pk0_values = [...new Set(records.map((r) => r.firstName))];
       const children_pk1_values = [...new Set(records.map((r) => r.lastName))];
-      const children_allRelated = await this.client.child.findMany(
-        {
-          ...children_opts,
-          ...(children_keysToInject.length > 0
-            ? { select: { ...children_sel, ...Object.fromEntries(children_keysToInject.map((k) => [k, true])) } }
-            : {}),
-          take: undefined,
-          skip: undefined,
-          where: { motherFirstName: { in: children_pk0_values }, motherLastName: { in: children_pk1_values } },
-        },
-        { tx }
-      );
-      const children_take = attach_children !== true ? (attach_children as Prisma.ChildFindManyArgs).take : undefined;
-      const children_skip = attach_children !== true ? (attach_children as Prisma.ChildFindManyArgs).skip : undefined;
       children_hashMap = new Map<string, unknown[]>();
-      for (const related of children_allRelated) {
-        const _r = related as Record<string, unknown>;
-        const key = JSON.stringify([_r["motherFirstName"], _r["motherLastName"]]);
-        if (!children_hashMap!.has(key)) children_hashMap!.set(key, []);
-        const value =
-          children_keysToInject.length > 0
-            ? Object.fromEntries(Object.entries(_r).filter(([k]) => !children_keysToInject.includes(k)))
-            : _r;
-        children_hashMap!.get(key)!.push(value as unknown);
-      }
-      if (children_skip !== undefined || children_take !== undefined) {
-        for (const [key, group] of children_hashMap!) {
-          const start = children_skip ?? 0;
-          const end = children_take !== undefined ? start + children_take : undefined;
-          children_hashMap!.set(key, group.slice(start, end));
+      const children_userWhere = children_opts.where as Record<string, unknown> | undefined;
+      if (children_cursor !== undefined || children_distinct !== undefined) {
+        for (const parent of records) {
+          const children_perParentFkWhere = { motherFirstName: parent.firstName, motherLastName: parent.lastName };
+          const children_perParentWhere = children_userWhere
+            ? { AND: [children_userWhere, children_perParentFkWhere] }
+            : children_perParentFkWhere;
+          const children = await this.client.child.findMany(
+            {
+              ...children_opts,
+              ...(children_keysToInject.length > 0
+                ? { select: { ...children_sel, ...Object.fromEntries(children_keysToInject.map((k) => [k, true])) } }
+                : {}),
+              where: children_perParentWhere,
+            },
+            { tx }
+          );
+          const stripped = children.map((c) => {
+            const _r = c as Record<string, unknown>;
+            return children_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !children_keysToInject.includes(k)))
+              : _r;
+          });
+          children_hashMap!.set(JSON.stringify([parent.firstName, parent.lastName]), stripped as unknown[]);
+        }
+      } else {
+        const children_fkWhere = {
+          motherFirstName: { in: children_pk0_values },
+          motherLastName: { in: children_pk1_values },
+        };
+        const children_where = children_userWhere ? { AND: [children_userWhere, children_fkWhere] } : children_fkWhere;
+        const children_allRelated = await this.client.child.findMany(
+          {
+            ...children_opts,
+            ...(children_keysToInject.length > 0
+              ? { select: { ...children_sel, ...Object.fromEntries(children_keysToInject.map((k) => [k, true])) } }
+              : {}),
+            take: undefined,
+            skip: undefined,
+            where: children_where,
+          },
+          { tx }
+        );
+        for (const related of children_allRelated) {
+          const _r = related as Record<string, unknown>;
+          const key = JSON.stringify([_r["motherFirstName"], _r["motherLastName"]]);
+          if (!children_hashMap!.has(key)) children_hashMap!.set(key, []);
+          const value =
+            children_keysToInject.length > 0
+              ? Object.fromEntries(Object.entries(_r).filter(([k]) => !children_keysToInject.includes(k)))
+              : _r;
+          children_hashMap!.get(key)!.push(value as unknown);
+        }
+        if (children_skip !== undefined || children_take !== undefined) {
+          for (const [key, group] of children_hashMap!) {
+            let sliced = group;
+            if (children_skip !== undefined) sliced = sliced.slice(children_skip);
+            if (children_take !== undefined)
+              sliced = children_take < 0 ? sliced.slice(children_take) : sliced.slice(0, children_take);
+            children_hashMap!.set(key, sliced);
+          }
         }
       }
     }
@@ -15153,13 +15584,19 @@ class MotherIDBClass extends BaseIDBModelClass<"Mother"> {
         : [];
       const husband_pk0_values = [...new Set(records.map((r) => r.firstName))];
       const husband_pk1_values = [...new Set(records.map((r) => r.lastName))];
+      const husband_userWhere = husband_opts.where as Record<string, unknown> | undefined;
+      const husband_fkWhere = {
+        motherFirstName: { in: husband_pk0_values },
+        motherLastName: { in: husband_pk1_values },
+      };
+      const husband_where = husband_userWhere ? { AND: [husband_userWhere, husband_fkWhere] } : husband_fkWhere;
       const husband_related = await this.client.father.findMany(
         {
           ...husband_opts,
           ...(husband_keysToInject.length > 0
             ? { select: { ...husband_sel, ...Object.fromEntries(husband_keysToInject.map((k) => [k, true])) } }
             : {}),
-          where: { motherFirstName: { in: husband_pk0_values }, motherLastName: { in: husband_pk1_values } },
+          where: husband_where,
         },
         { tx }
       );
@@ -15182,13 +15619,16 @@ class MotherIDBClass extends BaseIDBModelClass<"Mother"> {
       const user_sel = user_opts.select as Record<string, boolean> | undefined;
       const user_keysToInject = user_sel ? (["id"] as string[]).filter((k) => !user_sel![k]) : [];
       const user_fkValues = [...new Set(records.map((r) => r.userId).filter((v) => v !== null && v !== undefined))];
+      const user_userWhere = user_opts.where as Record<string, unknown> | undefined;
+      const user_fkWhere = { id: { in: user_fkValues } };
+      const user_where = user_userWhere ? { AND: [user_userWhere, user_fkWhere] } : user_fkWhere;
       const user_related = await this.client.user.findMany(
         {
           ...user_opts,
           ...(user_keysToInject.length > 0
             ? { select: { ...user_sel, ...Object.fromEntries(user_keysToInject.map((k) => [k, true])) } }
             : {}),
-          where: { id: { in: user_fkValues } },
+          where: user_where,
         },
         { tx }
       );
@@ -16645,13 +17085,16 @@ class ChildIDBClass extends BaseIDBModelClass<"Child"> {
       const user_sel = user_opts.select as Record<string, boolean> | undefined;
       const user_keysToInject = user_sel ? (["id"] as string[]).filter((k) => !user_sel![k]) : [];
       const user_fkValues = [...new Set(records.map((r) => r.userId).filter((v) => v !== null && v !== undefined))];
+      const user_userWhere = user_opts.where as Record<string, unknown> | undefined;
+      const user_fkWhere = { id: { in: user_fkValues } };
+      const user_where = user_userWhere ? { AND: [user_userWhere, user_fkWhere] } : user_fkWhere;
       const user_related = await this.client.user.findMany(
         {
           ...user_opts,
           ...(user_keysToInject.length > 0
             ? { select: { ...user_sel, ...Object.fromEntries(user_keysToInject.map((k) => [k, true])) } }
             : {}),
-          where: { id: { in: user_fkValues } },
+          where: user_where,
         },
         { tx }
       );
@@ -16681,13 +17124,16 @@ class ChildIDBClass extends BaseIDBModelClass<"Child"> {
       const father_pk1_values = [
         ...new Set(records.map((r) => r.fatherFirstName).filter((v) => v !== null && v !== undefined)),
       ];
+      const father_userWhere = father_opts.where as Record<string, unknown> | undefined;
+      const father_fkWhere = { lastName: { in: father_pk0_values }, firstName: { in: father_pk1_values } };
+      const father_where = father_userWhere ? { AND: [father_userWhere, father_fkWhere] } : father_fkWhere;
       const father_related = await this.client.father.findMany(
         {
           ...father_opts,
           ...(father_keysToInject.length > 0
             ? { select: { ...father_sel, ...Object.fromEntries(father_keysToInject.map((k) => [k, true])) } }
             : {}),
-          where: { lastName: { in: father_pk0_values }, firstName: { in: father_pk1_values } },
+          where: father_where,
         },
         { tx }
       );
@@ -16717,13 +17163,16 @@ class ChildIDBClass extends BaseIDBModelClass<"Child"> {
       const mother_pk1_values = [
         ...new Set(records.map((r) => r.motherLastName).filter((v) => v !== null && v !== undefined)),
       ];
+      const mother_userWhere = mother_opts.where as Record<string, unknown> | undefined;
+      const mother_fkWhere = { firstName: { in: mother_pk0_values }, lastName: { in: mother_pk1_values } };
+      const mother_where = mother_userWhere ? { AND: [mother_userWhere, mother_fkWhere] } : mother_fkWhere;
       const mother_related = await this.client.mother.findMany(
         {
           ...mother_opts,
           ...(mother_keysToInject.length > 0
             ? { select: { ...mother_sel, ...Object.fromEntries(mother_keysToInject.map((k) => [k, true])) } }
             : {}),
-          where: { firstName: { in: mother_pk0_values }, lastName: { in: mother_pk1_values } },
+          where: mother_where,
         },
         { tx }
       );

--- a/apps/usage/src/lib/prisma-idb/client/prisma-idb-client.ts
+++ b/apps/usage/src/lib/prisma-idb/client/prisma-idb-client.ts
@@ -534,6 +534,24 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
   ): Promise<Prisma.Result<Prisma.UserDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.UserDelegate, Q, "findFirstOrThrow">[];
     const attach_profile = query.select?.profile || query.include?.profile;
+    const attach_posts = query.select?.posts || query.include?.posts;
+    const attach_comments = query.select?.comments || query.include?.comments;
+    const attach_Child = query.select?.Child || query.include?.Child;
+    const attach_Father = query.select?.Father || query.include?.Father;
+    const attach_Mother = query.select?.Mother || query.include?.Mother;
+    const attach_groups = query.select?.groups || query.include?.groups;
+    const attach_todos = query.select?.todos || query.include?.todos;
+    if (
+      !attach_profile &&
+      !attach_posts &&
+      !attach_comments &&
+      !attach_Child &&
+      !attach_Father &&
+      !attach_Mother &&
+      !attach_groups &&
+      !attach_todos
+    )
+      return records as Prisma.Result<Prisma.UserDelegate, Q, "findFirstOrThrow">[];
     let profile_hashMap: Map<string, unknown> | undefined;
     if (attach_profile) {
       const profile_opts = (attach_profile === true ? {} : attach_profile) as Record<string, unknown>;
@@ -565,7 +583,6 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
         })
       );
     }
-    const attach_posts = query.select?.posts || query.include?.posts;
     let posts_hashMap: Map<string, unknown[]> | undefined;
     if (attach_posts) {
       const posts_opts = (attach_posts === true ? {} : attach_posts) as Record<string, unknown>;
@@ -641,7 +658,6 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
         }
       }
     }
-    const attach_comments = query.select?.comments || query.include?.comments;
     let comments_hashMap: Map<string, unknown[]> | undefined;
     if (attach_comments) {
       const comments_opts = (attach_comments === true ? {} : attach_comments) as Record<string, unknown>;
@@ -718,7 +734,6 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
         }
       }
     }
-    const attach_Child = query.select?.Child || query.include?.Child;
     let Child_hashMap: Map<string, unknown[]> | undefined;
     if (attach_Child) {
       const Child_opts = (attach_Child === true ? {} : attach_Child) as Record<string, unknown>;
@@ -794,7 +809,6 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
         }
       }
     }
-    const attach_Father = query.select?.Father || query.include?.Father;
     let Father_hashMap: Map<string, unknown[]> | undefined;
     if (attach_Father) {
       const Father_opts = (attach_Father === true ? {} : attach_Father) as Record<string, unknown>;
@@ -870,7 +884,6 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
         }
       }
     }
-    const attach_Mother = query.select?.Mother || query.include?.Mother;
     let Mother_hashMap: Map<string, unknown[]> | undefined;
     if (attach_Mother) {
       const Mother_opts = (attach_Mother === true ? {} : attach_Mother) as Record<string, unknown>;
@@ -946,7 +959,6 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
         }
       }
     }
-    const attach_groups = query.select?.groups || query.include?.groups;
     let groups_hashMap: Map<string, unknown[]> | undefined;
     if (attach_groups) {
       const groups_opts = (attach_groups === true ? {} : attach_groups) as Record<string, unknown>;
@@ -1022,7 +1034,6 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
         }
       }
     }
-    const attach_todos = query.select?.todos || query.include?.todos;
     let todos_hashMap: Map<string, unknown[]> | undefined;
     if (attach_todos) {
       const todos_opts = (attach_todos === true ? {} : attach_todos) as Record<string, unknown>;
@@ -3818,6 +3829,7 @@ class GroupIDBClass extends BaseIDBModelClass<"Group"> {
   ): Promise<Prisma.Result<Prisma.GroupDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.GroupDelegate, Q, "findFirstOrThrow">[];
     const attach_userGroups = query.select?.userGroups || query.include?.userGroups;
+    if (!attach_userGroups) return records as Prisma.Result<Prisma.GroupDelegate, Q, "findFirstOrThrow">[];
     let userGroups_hashMap: Map<string, unknown[]> | undefined;
     if (attach_userGroups) {
       const userGroups_opts = (attach_userGroups === true ? {} : attach_userGroups) as Record<string, unknown>;
@@ -4797,6 +4809,7 @@ class ProfileIDBClass extends BaseIDBModelClass<"Profile"> {
   ): Promise<Prisma.Result<Prisma.ProfileDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.ProfileDelegate, Q, "findFirstOrThrow">[];
     const attach_user = query.select?.user || query.include?.user;
+    if (!attach_user) return records as Prisma.Result<Prisma.ProfileDelegate, Q, "findFirstOrThrow">[];
     let user_hashMap: Map<string, unknown> | undefined;
     if (attach_user) {
       const user_opts = (attach_user === true ? {} : attach_user) as Record<string, unknown>;
@@ -5689,6 +5702,9 @@ class PostIDBClass extends BaseIDBModelClass<"Post"> {
   ): Promise<Prisma.Result<Prisma.PostDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.PostDelegate, Q, "findFirstOrThrow">[];
     const attach_author = query.select?.author || query.include?.author;
+    const attach_comments = query.select?.comments || query.include?.comments;
+    if (!attach_author && !attach_comments)
+      return records as Prisma.Result<Prisma.PostDelegate, Q, "findFirstOrThrow">[];
     let author_hashMap: Map<string, unknown> | undefined;
     if (attach_author) {
       const author_opts = (attach_author === true ? {} : attach_author) as Record<string, unknown>;
@@ -5720,7 +5736,6 @@ class PostIDBClass extends BaseIDBModelClass<"Post"> {
         })
       );
     }
-    const attach_comments = query.select?.comments || query.include?.comments;
     let comments_hashMap: Map<string, unknown[]> | undefined;
     if (attach_comments) {
       const comments_opts = (attach_comments === true ? {} : attach_comments) as Record<string, unknown>;
@@ -6942,6 +6957,8 @@ class CommentIDBClass extends BaseIDBModelClass<"Comment"> {
   ): Promise<Prisma.Result<Prisma.CommentDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.CommentDelegate, Q, "findFirstOrThrow">[];
     const attach_post = query.select?.post || query.include?.post;
+    const attach_user = query.select?.user || query.include?.user;
+    if (!attach_post && !attach_user) return records as Prisma.Result<Prisma.CommentDelegate, Q, "findFirstOrThrow">[];
     let post_hashMap: Map<string, unknown> | undefined;
     if (attach_post) {
       const post_opts = (attach_post === true ? {} : attach_post) as Record<string, unknown>;
@@ -6973,7 +6990,6 @@ class CommentIDBClass extends BaseIDBModelClass<"Comment"> {
         })
       );
     }
-    const attach_user = query.select?.user || query.include?.user;
     let user_hashMap: Map<string, unknown> | undefined;
     if (attach_user) {
       const user_opts = (attach_user === true ? {} : attach_user) as Record<string, unknown>;
@@ -7982,6 +7998,7 @@ class TodoIDBClass extends BaseIDBModelClass<"Todo"> {
   ): Promise<Prisma.Result<Prisma.TodoDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.TodoDelegate, Q, "findFirstOrThrow">[];
     const attach_user = query.select?.user || query.include?.user;
+    if (!attach_user) return records as Prisma.Result<Prisma.TodoDelegate, Q, "findFirstOrThrow">[];
     let user_hashMap: Map<string, unknown> | undefined;
     if (attach_user) {
       const user_opts = (attach_user === true ? {} : attach_user) as Record<string, unknown>;
@@ -10828,6 +10845,12 @@ class ModelWithOptionalRelationToUniqueAttributesIDBClass extends BaseIDBModelCl
         "findFirstOrThrow"
       >[];
     const attach_link = query.select?.link || query.include?.link;
+    if (!attach_link)
+      return records as Prisma.Result<
+        Prisma.ModelWithOptionalRelationToUniqueAttributesDelegate,
+        Q,
+        "findFirstOrThrow"
+      >[];
     let link_hashMap: Map<string, unknown> | undefined;
     if (attach_link) {
       const link_opts = (attach_link === true ? {} : attach_link) as Record<string, unknown>;
@@ -11787,6 +11810,8 @@ class ModelWithUniqueAttributesIDBClass extends BaseIDBModelClass<"ModelWithUniq
   ): Promise<Prisma.Result<Prisma.ModelWithUniqueAttributesDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.ModelWithUniqueAttributesDelegate, Q, "findFirstOrThrow">[];
     const attach_links = query.select?.links || query.include?.links;
+    if (!attach_links)
+      return records as Prisma.Result<Prisma.ModelWithUniqueAttributesDelegate, Q, "findFirstOrThrow">[];
     let links_hashMap: Map<string, unknown[]> | undefined;
     if (attach_links) {
       const links_opts = (attach_links === true ? {} : attach_links) as Record<string, unknown>;
@@ -12854,6 +12879,9 @@ class UserGroupIDBClass extends BaseIDBModelClass<"UserGroup"> {
   ): Promise<Prisma.Result<Prisma.UserGroupDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.UserGroupDelegate, Q, "findFirstOrThrow">[];
     const attach_group = query.select?.group || query.include?.group;
+    const attach_user = query.select?.user || query.include?.user;
+    if (!attach_group && !attach_user)
+      return records as Prisma.Result<Prisma.UserGroupDelegate, Q, "findFirstOrThrow">[];
     let group_hashMap: Map<string, unknown> | undefined;
     if (attach_group) {
       const group_opts = (attach_group === true ? {} : attach_group) as Record<string, unknown>;
@@ -12885,7 +12913,6 @@ class UserGroupIDBClass extends BaseIDBModelClass<"UserGroup"> {
         })
       );
     }
-    const attach_user = query.select?.user || query.include?.user;
     let user_hashMap: Map<string, unknown> | undefined;
     if (attach_user) {
       const user_opts = (attach_user === true ? {} : attach_user) as Record<string, unknown>;
@@ -13996,6 +14023,10 @@ class FatherIDBClass extends BaseIDBModelClass<"Father"> {
   ): Promise<Prisma.Result<Prisma.FatherDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.FatherDelegate, Q, "findFirstOrThrow">[];
     const attach_children = query.select?.children || query.include?.children;
+    const attach_wife = query.select?.wife || query.include?.wife;
+    const attach_user = query.select?.user || query.include?.user;
+    if (!attach_children && !attach_wife && !attach_user)
+      return records as Prisma.Result<Prisma.FatherDelegate, Q, "findFirstOrThrow">[];
     let children_hashMap: Map<string, unknown[]> | undefined;
     if (attach_children) {
       const children_opts = (attach_children === true ? {} : attach_children) as Record<string, unknown>;
@@ -14078,7 +14109,6 @@ class FatherIDBClass extends BaseIDBModelClass<"Father"> {
         }
       }
     }
-    const attach_wife = query.select?.wife || query.include?.wife;
     let wife_hashMap: Map<string, unknown> | undefined;
     if (attach_wife) {
       const wife_opts = (attach_wife === true ? {} : attach_wife) as Record<string, unknown>;
@@ -14115,7 +14145,6 @@ class FatherIDBClass extends BaseIDBModelClass<"Father"> {
         })
       );
     }
-    const attach_user = query.select?.user || query.include?.user;
     let user_hashMap: Map<string, unknown> | undefined;
     if (attach_user) {
       const user_opts = (attach_user === true ? {} : attach_user) as Record<string, unknown>;
@@ -15604,6 +15633,10 @@ class MotherIDBClass extends BaseIDBModelClass<"Mother"> {
   ): Promise<Prisma.Result<Prisma.MotherDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.MotherDelegate, Q, "findFirstOrThrow">[];
     const attach_children = query.select?.children || query.include?.children;
+    const attach_husband = query.select?.husband || query.include?.husband;
+    const attach_user = query.select?.user || query.include?.user;
+    if (!attach_children && !attach_husband && !attach_user)
+      return records as Prisma.Result<Prisma.MotherDelegate, Q, "findFirstOrThrow">[];
     let children_hashMap: Map<string, unknown[]> | undefined;
     if (attach_children) {
       const children_opts = (attach_children === true ? {} : attach_children) as Record<string, unknown>;
@@ -15686,7 +15719,6 @@ class MotherIDBClass extends BaseIDBModelClass<"Mother"> {
         }
       }
     }
-    const attach_husband = query.select?.husband || query.include?.husband;
     let husband_hashMap: Map<string, unknown> | undefined;
     if (attach_husband) {
       const husband_opts = (attach_husband === true ? {} : attach_husband) as Record<string, unknown>;
@@ -15724,7 +15756,6 @@ class MotherIDBClass extends BaseIDBModelClass<"Mother"> {
         })
       );
     }
-    const attach_user = query.select?.user || query.include?.user;
     let user_hashMap: Map<string, unknown> | undefined;
     if (attach_user) {
       const user_opts = (attach_user === true ? {} : attach_user) as Record<string, unknown>;
@@ -17202,6 +17233,10 @@ class ChildIDBClass extends BaseIDBModelClass<"Child"> {
   ): Promise<Prisma.Result<Prisma.ChildDelegate, Q, "findFirstOrThrow">[]> {
     if (!query) return records as Prisma.Result<Prisma.ChildDelegate, Q, "findFirstOrThrow">[];
     const attach_user = query.select?.user || query.include?.user;
+    const attach_father = query.select?.father || query.include?.father;
+    const attach_mother = query.select?.mother || query.include?.mother;
+    if (!attach_user && !attach_father && !attach_mother)
+      return records as Prisma.Result<Prisma.ChildDelegate, Q, "findFirstOrThrow">[];
     let user_hashMap: Map<string, unknown> | undefined;
     if (attach_user) {
       const user_opts = (attach_user === true ? {} : attach_user) as Record<string, unknown>;
@@ -17233,7 +17268,6 @@ class ChildIDBClass extends BaseIDBModelClass<"Child"> {
         })
       );
     }
-    const attach_father = query.select?.father || query.include?.father;
     let father_hashMap: Map<string, unknown> | undefined;
     if (attach_father) {
       const father_opts = (attach_father === true ? {} : attach_father) as Record<string, unknown>;
@@ -17272,7 +17306,6 @@ class ChildIDBClass extends BaseIDBModelClass<"Child"> {
         })
       );
     }
-    const attach_mother = query.select?.mother || query.include?.mother;
     let mother_hashMap: Map<string, unknown> | undefined;
     if (attach_mother) {
       const mother_opts = (attach_mother === true ? {} : attach_mother) as Record<string, unknown>;

--- a/apps/usage/src/lib/prisma-idb/client/prisma-idb-client.ts
+++ b/apps/usage/src/lib/prisma-idb/client/prisma-idb-client.ts
@@ -628,6 +628,9 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
           posts_hashMap!.get(key)!.push(value as unknown);
         }
         if (posts_skip !== undefined || posts_take !== undefined) {
+          if (posts_skip !== undefined && (!Number.isInteger(posts_skip) || posts_skip < 0))
+            throw new Error("skip must be a non-negative integer");
+          if (posts_take !== undefined && !Number.isInteger(posts_take)) throw new Error("take must be an integer");
           for (const [key, group] of posts_hashMap!) {
             let sliced = group;
             if (posts_skip !== undefined) sliced = sliced.slice(posts_skip);
@@ -701,6 +704,10 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
           comments_hashMap!.get(key)!.push(value as unknown);
         }
         if (comments_skip !== undefined || comments_take !== undefined) {
+          if (comments_skip !== undefined && (!Number.isInteger(comments_skip) || comments_skip < 0))
+            throw new Error("skip must be a non-negative integer");
+          if (comments_take !== undefined && !Number.isInteger(comments_take))
+            throw new Error("take must be an integer");
           for (const [key, group] of comments_hashMap!) {
             let sliced = group;
             if (comments_skip !== undefined) sliced = sliced.slice(comments_skip);
@@ -774,6 +781,9 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
           Child_hashMap!.get(key)!.push(value as unknown);
         }
         if (Child_skip !== undefined || Child_take !== undefined) {
+          if (Child_skip !== undefined && (!Number.isInteger(Child_skip) || Child_skip < 0))
+            throw new Error("skip must be a non-negative integer");
+          if (Child_take !== undefined && !Number.isInteger(Child_take)) throw new Error("take must be an integer");
           for (const [key, group] of Child_hashMap!) {
             let sliced = group;
             if (Child_skip !== undefined) sliced = sliced.slice(Child_skip);
@@ -847,6 +857,9 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
           Father_hashMap!.get(key)!.push(value as unknown);
         }
         if (Father_skip !== undefined || Father_take !== undefined) {
+          if (Father_skip !== undefined && (!Number.isInteger(Father_skip) || Father_skip < 0))
+            throw new Error("skip must be a non-negative integer");
+          if (Father_take !== undefined && !Number.isInteger(Father_take)) throw new Error("take must be an integer");
           for (const [key, group] of Father_hashMap!) {
             let sliced = group;
             if (Father_skip !== undefined) sliced = sliced.slice(Father_skip);
@@ -920,6 +933,9 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
           Mother_hashMap!.get(key)!.push(value as unknown);
         }
         if (Mother_skip !== undefined || Mother_take !== undefined) {
+          if (Mother_skip !== undefined && (!Number.isInteger(Mother_skip) || Mother_skip < 0))
+            throw new Error("skip must be a non-negative integer");
+          if (Mother_take !== undefined && !Number.isInteger(Mother_take)) throw new Error("take must be an integer");
           for (const [key, group] of Mother_hashMap!) {
             let sliced = group;
             if (Mother_skip !== undefined) sliced = sliced.slice(Mother_skip);
@@ -993,6 +1009,9 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
           groups_hashMap!.get(key)!.push(value as unknown);
         }
         if (groups_skip !== undefined || groups_take !== undefined) {
+          if (groups_skip !== undefined && (!Number.isInteger(groups_skip) || groups_skip < 0))
+            throw new Error("skip must be a non-negative integer");
+          if (groups_take !== undefined && !Number.isInteger(groups_take)) throw new Error("take must be an integer");
           for (const [key, group] of groups_hashMap!) {
             let sliced = group;
             if (groups_skip !== undefined) sliced = sliced.slice(groups_skip);
@@ -1066,6 +1085,9 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
           todos_hashMap!.get(key)!.push(value as unknown);
         }
         if (todos_skip !== undefined || todos_take !== undefined) {
+          if (todos_skip !== undefined && (!Number.isInteger(todos_skip) || todos_skip < 0))
+            throw new Error("skip must be a non-negative integer");
+          if (todos_take !== undefined && !Number.isInteger(todos_take)) throw new Error("take must be an integer");
           for (const [key, group] of todos_hashMap!) {
             let sliced = group;
             if (todos_skip !== undefined) sliced = sliced.slice(todos_skip);
@@ -1079,28 +1101,52 @@ class UserIDBClass extends BaseIDBModelClass<"User"> {
     const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
       if (attach_profile) {
-        unsafeRecord["profile"] = profile_hashMap!.get(JSON.stringify(record.id)) ?? null;
+        unsafeRecord["profile"] = (() => {
+          const _v = profile_hashMap!.get(JSON.stringify(record.id));
+          return _v == null ? null : structuredClone(_v);
+        })();
       }
       if (attach_posts) {
-        unsafeRecord["posts"] = posts_hashMap!.get(JSON.stringify(record.id)) ?? [];
+        unsafeRecord["posts"] = (() => {
+          const _v = posts_hashMap!.get(JSON.stringify(record.id));
+          return _v == null ? [] : structuredClone(_v);
+        })();
       }
       if (attach_comments) {
-        unsafeRecord["comments"] = comments_hashMap!.get(JSON.stringify(record.id)) ?? [];
+        unsafeRecord["comments"] = (() => {
+          const _v = comments_hashMap!.get(JSON.stringify(record.id));
+          return _v == null ? [] : structuredClone(_v);
+        })();
       }
       if (attach_Child) {
-        unsafeRecord["Child"] = Child_hashMap!.get(JSON.stringify(record.id)) ?? [];
+        unsafeRecord["Child"] = (() => {
+          const _v = Child_hashMap!.get(JSON.stringify(record.id));
+          return _v == null ? [] : structuredClone(_v);
+        })();
       }
       if (attach_Father) {
-        unsafeRecord["Father"] = Father_hashMap!.get(JSON.stringify(record.id)) ?? [];
+        unsafeRecord["Father"] = (() => {
+          const _v = Father_hashMap!.get(JSON.stringify(record.id));
+          return _v == null ? [] : structuredClone(_v);
+        })();
       }
       if (attach_Mother) {
-        unsafeRecord["Mother"] = Mother_hashMap!.get(JSON.stringify(record.id)) ?? [];
+        unsafeRecord["Mother"] = (() => {
+          const _v = Mother_hashMap!.get(JSON.stringify(record.id));
+          return _v == null ? [] : structuredClone(_v);
+        })();
       }
       if (attach_groups) {
-        unsafeRecord["groups"] = groups_hashMap!.get(JSON.stringify(record.id)) ?? [];
+        unsafeRecord["groups"] = (() => {
+          const _v = groups_hashMap!.get(JSON.stringify(record.id));
+          return _v == null ? [] : structuredClone(_v);
+        })();
       }
       if (attach_todos) {
-        unsafeRecord["todos"] = todos_hashMap!.get(JSON.stringify(record.id)) ?? [];
+        unsafeRecord["todos"] = (() => {
+          const _v = todos_hashMap!.get(JSON.stringify(record.id));
+          return _v == null ? [] : structuredClone(_v);
+        })();
       }
       return unsafeRecord;
     });
@@ -3840,6 +3886,10 @@ class GroupIDBClass extends BaseIDBModelClass<"Group"> {
           userGroups_hashMap!.get(key)!.push(value as unknown);
         }
         if (userGroups_skip !== undefined || userGroups_take !== undefined) {
+          if (userGroups_skip !== undefined && (!Number.isInteger(userGroups_skip) || userGroups_skip < 0))
+            throw new Error("skip must be a non-negative integer");
+          if (userGroups_take !== undefined && !Number.isInteger(userGroups_take))
+            throw new Error("take must be an integer");
           for (const [key, group] of userGroups_hashMap!) {
             let sliced = group;
             if (userGroups_skip !== undefined) sliced = sliced.slice(userGroups_skip);
@@ -3853,7 +3903,10 @@ class GroupIDBClass extends BaseIDBModelClass<"Group"> {
     const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
       if (attach_userGroups) {
-        unsafeRecord["userGroups"] = userGroups_hashMap!.get(JSON.stringify(record.id)) ?? [];
+        unsafeRecord["userGroups"] = (() => {
+          const _v = userGroups_hashMap!.get(JSON.stringify(record.id));
+          return _v == null ? [] : structuredClone(_v);
+        })();
       }
       return unsafeRecord;
     });
@@ -4778,7 +4831,10 @@ class ProfileIDBClass extends BaseIDBModelClass<"Profile"> {
     const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
       if (attach_user) {
-        unsafeRecord["user"] = user_hashMap!.get(JSON.stringify(record.userId)) ?? null;
+        unsafeRecord["user"] = (() => {
+          const _v = user_hashMap!.get(JSON.stringify(record.userId));
+          return _v == null ? null : structuredClone(_v);
+        })();
       }
       return unsafeRecord;
     });
@@ -5727,6 +5783,10 @@ class PostIDBClass extends BaseIDBModelClass<"Post"> {
           comments_hashMap!.get(key)!.push(value as unknown);
         }
         if (comments_skip !== undefined || comments_take !== undefined) {
+          if (comments_skip !== undefined && (!Number.isInteger(comments_skip) || comments_skip < 0))
+            throw new Error("skip must be a non-negative integer");
+          if (comments_take !== undefined && !Number.isInteger(comments_take))
+            throw new Error("take must be an integer");
           for (const [key, group] of comments_hashMap!) {
             let sliced = group;
             if (comments_skip !== undefined) sliced = sliced.slice(comments_skip);
@@ -5741,10 +5801,18 @@ class PostIDBClass extends BaseIDBModelClass<"Post"> {
       const unsafeRecord = record as Record<string, unknown>;
       if (attach_author) {
         unsafeRecord["author"] =
-          record.authorId === null ? null : (author_hashMap!.get(JSON.stringify(record.authorId)) ?? null);
+          record.authorId === null
+            ? null
+            : (() => {
+                const _v = author_hashMap!.get(JSON.stringify(record.authorId));
+                return _v == null ? null : structuredClone(_v);
+              })();
       }
       if (attach_comments) {
-        unsafeRecord["comments"] = comments_hashMap!.get(JSON.stringify(record.id)) ?? [];
+        unsafeRecord["comments"] = (() => {
+          const _v = comments_hashMap!.get(JSON.stringify(record.id));
+          return _v == null ? [] : structuredClone(_v);
+        })();
       }
       return unsafeRecord;
     });
@@ -6940,10 +7008,16 @@ class CommentIDBClass extends BaseIDBModelClass<"Comment"> {
     const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
       if (attach_post) {
-        unsafeRecord["post"] = post_hashMap!.get(JSON.stringify(record.postId)) ?? null;
+        unsafeRecord["post"] = (() => {
+          const _v = post_hashMap!.get(JSON.stringify(record.postId));
+          return _v == null ? null : structuredClone(_v);
+        })();
       }
       if (attach_user) {
-        unsafeRecord["user"] = user_hashMap!.get(JSON.stringify(record.userId)) ?? null;
+        unsafeRecord["user"] = (() => {
+          const _v = user_hashMap!.get(JSON.stringify(record.userId));
+          return _v == null ? null : structuredClone(_v);
+        })();
       }
       return unsafeRecord;
     });
@@ -7942,7 +8016,10 @@ class TodoIDBClass extends BaseIDBModelClass<"Todo"> {
     const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
       if (attach_user) {
-        unsafeRecord["user"] = user_hashMap!.get(JSON.stringify(record.userId)) ?? null;
+        unsafeRecord["user"] = (() => {
+          const _v = user_hashMap!.get(JSON.stringify(record.userId));
+          return _v == null ? null : structuredClone(_v);
+        })();
       }
       return unsafeRecord;
     });
@@ -10786,7 +10863,12 @@ class ModelWithOptionalRelationToUniqueAttributesIDBClass extends BaseIDBModelCl
       const unsafeRecord = record as Record<string, unknown>;
       if (attach_link) {
         unsafeRecord["link"] =
-          record.linkId === null ? null : (link_hashMap!.get(JSON.stringify(record.linkId)) ?? null);
+          record.linkId === null
+            ? null
+            : (() => {
+                const _v = link_hashMap!.get(JSON.stringify(record.linkId));
+                return _v == null ? null : structuredClone(_v);
+              })();
       }
       return unsafeRecord;
     });
@@ -11767,6 +11849,9 @@ class ModelWithUniqueAttributesIDBClass extends BaseIDBModelClass<"ModelWithUniq
           links_hashMap!.get(key)!.push(value as unknown);
         }
         if (links_skip !== undefined || links_take !== undefined) {
+          if (links_skip !== undefined && (!Number.isInteger(links_skip) || links_skip < 0))
+            throw new Error("skip must be a non-negative integer");
+          if (links_take !== undefined && !Number.isInteger(links_take)) throw new Error("take must be an integer");
           for (const [key, group] of links_hashMap!) {
             let sliced = group;
             if (links_skip !== undefined) sliced = sliced.slice(links_skip);
@@ -11780,7 +11865,10 @@ class ModelWithUniqueAttributesIDBClass extends BaseIDBModelClass<"ModelWithUniq
     const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
       if (attach_links) {
-        unsafeRecord["links"] = links_hashMap!.get(JSON.stringify(record.id)) ?? [];
+        unsafeRecord["links"] = (() => {
+          const _v = links_hashMap!.get(JSON.stringify(record.id));
+          return _v == null ? [] : structuredClone(_v);
+        })();
       }
       return unsafeRecord;
     });
@@ -12832,10 +12920,16 @@ class UserGroupIDBClass extends BaseIDBModelClass<"UserGroup"> {
     const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
       if (attach_group) {
-        unsafeRecord["group"] = group_hashMap!.get(JSON.stringify(record.groupId)) ?? null;
+        unsafeRecord["group"] = (() => {
+          const _v = group_hashMap!.get(JSON.stringify(record.groupId));
+          return _v == null ? null : structuredClone(_v);
+        })();
       }
       if (attach_user) {
-        unsafeRecord["user"] = user_hashMap!.get(JSON.stringify(record.userId)) ?? null;
+        unsafeRecord["user"] = (() => {
+          const _v = user_hashMap!.get(JSON.stringify(record.userId));
+          return _v == null ? null : structuredClone(_v);
+        })();
       }
       return unsafeRecord;
     });
@@ -13970,6 +14064,10 @@ class FatherIDBClass extends BaseIDBModelClass<"Father"> {
           children_hashMap!.get(key)!.push(value as unknown);
         }
         if (children_skip !== undefined || children_take !== undefined) {
+          if (children_skip !== undefined && (!Number.isInteger(children_skip) || children_skip < 0))
+            throw new Error("skip must be a non-negative integer");
+          if (children_take !== undefined && !Number.isInteger(children_take))
+            throw new Error("take must be an integer");
           for (const [key, group] of children_hashMap!) {
             let sliced = group;
             if (children_skip !== undefined) sliced = sliced.slice(children_skip);
@@ -14052,15 +14150,25 @@ class FatherIDBClass extends BaseIDBModelClass<"Father"> {
     const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
       if (attach_children) {
-        unsafeRecord["children"] = children_hashMap!.get(JSON.stringify([record.lastName, record.firstName])) ?? [];
+        unsafeRecord["children"] = (() => {
+          const _v = children_hashMap!.get(JSON.stringify([record.lastName, record.firstName]));
+          return _v == null ? [] : structuredClone(_v);
+        })();
       }
       if (attach_wife) {
-        unsafeRecord["wife"] =
-          wife_hashMap!.get(JSON.stringify([record.motherFirstName, record.motherLastName])) ?? null;
+        unsafeRecord["wife"] = (() => {
+          const _v = wife_hashMap!.get(JSON.stringify([record.motherFirstName, record.motherLastName]));
+          return _v == null ? null : structuredClone(_v);
+        })();
       }
       if (attach_user) {
         unsafeRecord["user"] =
-          record.userId === null ? null : (user_hashMap!.get(JSON.stringify(record.userId)) ?? null);
+          record.userId === null
+            ? null
+            : (() => {
+                const _v = user_hashMap!.get(JSON.stringify(record.userId));
+                return _v == null ? null : structuredClone(_v);
+              })();
       }
       return unsafeRecord;
     });
@@ -15564,6 +15672,10 @@ class MotherIDBClass extends BaseIDBModelClass<"Mother"> {
           children_hashMap!.get(key)!.push(value as unknown);
         }
         if (children_skip !== undefined || children_take !== undefined) {
+          if (children_skip !== undefined && (!Number.isInteger(children_skip) || children_skip < 0))
+            throw new Error("skip must be a non-negative integer");
+          if (children_take !== undefined && !Number.isInteger(children_take))
+            throw new Error("take must be an integer");
           for (const [key, group] of children_hashMap!) {
             let sliced = group;
             if (children_skip !== undefined) sliced = sliced.slice(children_skip);
@@ -15647,14 +15759,25 @@ class MotherIDBClass extends BaseIDBModelClass<"Mother"> {
     const recordsWithRelations = records.map((record) => {
       const unsafeRecord = record as Record<string, unknown>;
       if (attach_children) {
-        unsafeRecord["children"] = children_hashMap!.get(JSON.stringify([record.firstName, record.lastName])) ?? [];
+        unsafeRecord["children"] = (() => {
+          const _v = children_hashMap!.get(JSON.stringify([record.firstName, record.lastName]));
+          return _v == null ? [] : structuredClone(_v);
+        })();
       }
       if (attach_husband) {
-        unsafeRecord["husband"] = husband_hashMap!.get(JSON.stringify([record.firstName, record.lastName])) ?? null;
+        unsafeRecord["husband"] = (() => {
+          const _v = husband_hashMap!.get(JSON.stringify([record.firstName, record.lastName]));
+          return _v == null ? null : structuredClone(_v);
+        })();
       }
       if (attach_user) {
         unsafeRecord["user"] =
-          record.userId === null ? null : (user_hashMap!.get(JSON.stringify(record.userId)) ?? null);
+          record.userId === null
+            ? null
+            : (() => {
+                const _v = user_hashMap!.get(JSON.stringify(record.userId));
+                return _v == null ? null : structuredClone(_v);
+              })();
       }
       return unsafeRecord;
     });
@@ -17192,15 +17315,24 @@ class ChildIDBClass extends BaseIDBModelClass<"Child"> {
       const unsafeRecord = record as Record<string, unknown>;
       if (attach_user) {
         unsafeRecord["user"] =
-          record.userId === null ? null : (user_hashMap!.get(JSON.stringify(record.userId)) ?? null);
+          record.userId === null
+            ? null
+            : (() => {
+                const _v = user_hashMap!.get(JSON.stringify(record.userId));
+                return _v == null ? null : structuredClone(_v);
+              })();
       }
       if (attach_father) {
-        unsafeRecord["father"] =
-          father_hashMap!.get(JSON.stringify([record.fatherLastName, record.fatherFirstName])) ?? null;
+        unsafeRecord["father"] = (() => {
+          const _v = father_hashMap!.get(JSON.stringify([record.fatherLastName, record.fatherFirstName]));
+          return _v == null ? null : structuredClone(_v);
+        })();
       }
       if (attach_mother) {
-        unsafeRecord["mother"] =
-          mother_hashMap!.get(JSON.stringify([record.motherFirstName, record.motherLastName])) ?? null;
+        unsafeRecord["mother"] = (() => {
+          const _v = mother_hashMap!.get(JSON.stringify([record.motherFirstName, record.motherLastName]));
+          return _v == null ? null : structuredClone(_v);
+        })();
       }
       return unsafeRecord;
     });

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:sync": "turbo run test --filter=@prisma-idb/pidb-kanban-example",
     "test:schema-gen": "turbo run test --filter=@prisma-idb/schema-gen-tests",
     "test:benchmark": "turbo run test --filter=@prisma-idb/benchmark",
+    "benchmark:local": "bash scripts/benchmark-local.sh",
     "test:watch": "turbo run test:watch --no-cache",
     "generate": "turbo run generate",
     "clean": "turbo clean && rm -rf node_modules",

--- a/packages/generator/src/fileCreators/prisma-idb-client/classes/models/utils/_applyRelations.ts
+++ b/packages/generator/src/fileCreators/prisma-idb-client/classes/models/utils/_applyRelations.ts
@@ -366,6 +366,13 @@ function emitTypeCBatchPath(
 
   // Apply take/skip per group, mirroring `findMany`'s sign-aware semantics.
   writer.writeLine(`if (${field.name}_skip !== undefined || ${field.name}_take !== undefined)`).block(() => {
+    writer
+      .writeLine(
+        `if (${field.name}_skip !== undefined && (!Number.isInteger(${field.name}_skip) || ${field.name}_skip < 0)) throw new Error("skip must be a non-negative integer");`
+      )
+      .writeLine(
+        `if (${field.name}_take !== undefined && !Number.isInteger(${field.name}_take)) throw new Error("take must be an integer");`
+      );
     writer.writeLine(`for (const [key, group] of ${field.name}_hashMap!)`).block(() => {
       writer
         .writeLine(`let sliced = group;`)
@@ -418,10 +425,12 @@ function assignTypeARecord(writer: CodeBlockWriter, field: Field) {
 
   if (!field.isRequired) {
     writer.writeLine(
-      `unsafeRecord['${field.name}'] = record.${fkFields[0]} === null ? null : (${field.name}_hashMap!.get(${lookupKey}) ?? null);`
+      `unsafeRecord['${field.name}'] = record.${fkFields[0]} === null ? null : (() => { const _v = ${field.name}_hashMap!.get(${lookupKey}); return _v == null ? null : structuredClone(_v); })();`
     );
   } else {
-    writer.writeLine(`unsafeRecord['${field.name}'] = ${field.name}_hashMap!.get(${lookupKey}) ?? null;`);
+    writer.writeLine(
+      `unsafeRecord['${field.name}'] = (() => { const _v = ${field.name}_hashMap!.get(${lookupKey}); return _v == null ? null : structuredClone(_v); })();`
+    );
   }
 }
 
@@ -432,7 +441,9 @@ function assignTypeBRecord(writer: CodeBlockWriter, field: Field, otherField: Fi
       ? `JSON.stringify(record.${pkFields[0]})`
       : `JSON.stringify([${pkFields.map((f) => `record.${f}`).join(", ")}])`;
 
-  writer.writeLine(`unsafeRecord['${field.name}'] = ${field.name}_hashMap!.get(${lookupKey}) ?? null;`);
+  writer.writeLine(
+    `unsafeRecord['${field.name}'] = (() => { const _v = ${field.name}_hashMap!.get(${lookupKey}); return _v == null ? null : structuredClone(_v); })();`
+  );
 }
 
 function assignTypeCRecords(writer: CodeBlockWriter, field: Field, otherField: Field) {
@@ -442,7 +453,9 @@ function assignTypeCRecords(writer: CodeBlockWriter, field: Field, otherField: F
       ? `JSON.stringify(record.${pkFields[0]})`
       : `JSON.stringify([${pkFields.map((f) => `record.${f}`).join(", ")}])`;
 
-  writer.writeLine(`unsafeRecord['${field.name}'] = ${field.name}_hashMap!.get(${lookupKey}) ?? [];`);
+  writer.writeLine(
+    `unsafeRecord['${field.name}'] = (() => { const _v = ${field.name}_hashMap!.get(${lookupKey}); return _v == null ? [] : structuredClone(_v); })();`
+  );
 }
 
 function addReturn(writer: CodeBlockWriter, model: Model) {

--- a/packages/generator/src/fileCreators/prisma-idb-client/classes/models/utils/_applyRelations.ts
+++ b/packages/generator/src/fileCreators/prisma-idb-client/classes/models/utils/_applyRelations.ts
@@ -10,6 +10,11 @@ export function addApplyRelations(writer: CodeBlockWriter, model: Model, models:
     .writeLine(`query?: Q): Promise<Prisma.Result<Prisma.${model.name}Delegate, Q, 'findFirstOrThrow'>[]>`)
     .block(() => {
       addEarlyExit(writer, model);
+      const hasRelations = model.fields.some(({ kind }) => kind === "object");
+      if (!hasRelations) {
+        addNoRelationsEarlyExit(writer, model);
+        return;
+      }
       addAttachFlags(writer, model);
       addNoRelationsEarlyExit(writer, model);
       addHashJoinBuildPhase(writer, model, models);
@@ -40,7 +45,10 @@ function addAttachFlags(writer: CodeBlockWriter, model: Model) {
 
 function addNoRelationsEarlyExit(writer: CodeBlockWriter, model: Model) {
   const relationFields = model.fields.filter(({ kind }) => kind === "object");
-  if (relationFields.length === 0) return;
+  if (relationFields.length === 0) {
+    writer.writeLine(`return records as Prisma.Result<Prisma.${model.name}Delegate, Q, 'findFirstOrThrow'>[];`);
+    return;
+  }
   const condition = relationFields.map((f) => `!attach_${f.name}`).join(" && ");
   writer.writeLine(
     `if (${condition}) return records as Prisma.Result<Prisma.${model.name}Delegate, Q, 'findFirstOrThrow'>[];`

--- a/packages/generator/src/fileCreators/prisma-idb-client/classes/models/utils/_applyRelations.ts
+++ b/packages/generator/src/fileCreators/prisma-idb-client/classes/models/utils/_applyRelations.ts
@@ -1,5 +1,5 @@
 import CodeBlockWriter from "code-block-writer";
-import { getUniqueIdentifiers, toCamelCase } from "../../../../../helpers/utils";
+import { toCamelCase } from "../../../../../helpers/utils";
 import { Field, Model } from "../../../../types";
 
 export function addApplyRelations(writer: CodeBlockWriter, model: Model, models: readonly Model[]) {
@@ -10,7 +10,8 @@ export function addApplyRelations(writer: CodeBlockWriter, model: Model, models:
     .writeLine(`query?: Q): Promise<Prisma.Result<Prisma.${model.name}Delegate, Q, 'findFirstOrThrow'>[]>`)
     .block(() => {
       addEarlyExit(writer, model);
-      addRelationProcessing(writer, model, models);
+      addHashJoinBuildPhase(writer, model, models);
+      addHashJoinAssignPhase(writer, model, models);
       addReturn(writer, model);
     });
 }
@@ -21,108 +22,336 @@ function addEarlyExit(writer: CodeBlockWriter, model: Model) {
   );
 }
 
-function addRelationProcessing(writer: CodeBlockWriter, model: Model, models: readonly Model[]) {
+// ---------------------------------------------------------------------------
+// BUILD PHASE: one batch fetch per relation, build hash maps
+// ---------------------------------------------------------------------------
+
+function addHashJoinBuildPhase(writer: CodeBlockWriter, model: Model, models: readonly Model[]) {
+  const relationFields = model.fields.filter(({ kind }) => kind === "object");
+  const allFields = models.flatMap(({ fields }) => fields);
+
+  relationFields.forEach((field) => {
+    const otherField = allFields.find((_field) => _field.relationName === field.relationName && field !== _field)!;
+
+    writer.writeLine(`const attach_${field.name} = query.select?.${field.name} || query.include?.${field.name};`);
+
+    const mapValueType = field.isList ? "unknown[]" : "unknown";
+    writer.writeLine(`let ${field.name}_hashMap: Map<string, ${mapValueType}> | undefined;`);
+
+    writer.writeLine(`if (attach_${field.name})`).block(() => {
+      if (!field.isList) {
+        if (field.relationFromFields?.length) {
+          buildTypeAHashMap(writer, field);
+        } else {
+          buildTypeBHashMap(writer, field, otherField);
+        }
+      } else {
+        buildTypeCHashMap(writer, field, otherField);
+      }
+    });
+  });
+}
+
+/**
+ * Emits variables to detect and inject missing key fields into a `select` clause.
+ * `_opts`         – the full query options (or `{}` if `attach === true`)
+ * `_sel`          – the `select` sub-object (or `undefined`)
+ * `_keysToInject` – key fields absent from the select that must be temporarily added
+ */
+function emitKeyInjectionSetup(writer: CodeBlockWriter, fieldName: string, keyFields: readonly string[]) {
+  const keyFieldsLiteral = `[${keyFields.map((k) => `"${k}"`).join(", ")}]`;
+  writer
+    .writeLine(
+      `const ${fieldName}_opts = (attach_${fieldName} === true ? {} : attach_${fieldName}) as Record<string, unknown>;`
+    )
+    .writeLine(`const ${fieldName}_sel = ${fieldName}_opts.select as Record<string, boolean> | undefined;`)
+    .writeLine(
+      `const ${fieldName}_keysToInject = ${fieldName}_sel ? (${keyFieldsLiteral} as string[]).filter((k) => !${fieldName}_sel![k]) : [];`
+    );
+}
+
+/**
+ * Type A: FK lives on THIS model (e.g. Post.authorId → User.id).
+ * Batch-fetch the related model by PK, map key = JSON.stringify(related PK).
+ */
+function buildTypeAHashMap(writer: CodeBlockWriter, field: Field) {
+  const fkFields = field.relationFromFields!;
+  const pkFields = field.relationToFields!;
+
+  emitKeyInjectionSetup(writer, field.name, pkFields);
+
+  const mapKeyExpr =
+    pkFields.length === 1
+      ? `JSON.stringify(_r["${pkFields[0]}"])`
+      : `JSON.stringify([${pkFields.map((f) => `_r["${f}"]`).join(", ")}])`;
+
+  if (fkFields.length === 1) {
+    writer.writeLine(
+      `const ${field.name}_fkValues = [...new Set(records.map(r => r.${fkFields[0]}).filter(v => v !== null && v !== undefined))];`
+    );
+    writer
+      .writeLine(`const ${field.name}_related = await this.client.${toCamelCase(field.type)}.findMany(`)
+      .block(() => {
+        writer
+          .writeLine(`...${field.name}_opts,`)
+          .writeLine(
+            `...(${field.name}_keysToInject.length > 0 ? { select: { ...${field.name}_sel, ...Object.fromEntries(${field.name}_keysToInject.map(k => [k, true])) } } : {}),`
+          )
+          .writeLine(`where: { ${pkFields[0]}: { in: ${field.name}_fkValues } }`);
+      })
+      .writeLine(`, { tx });`);
+  } else {
+    // composite FK – collect per-component value sets for the IN filter
+    fkFields.forEach((fkField, idx) => {
+      writer.writeLine(
+        `const ${field.name}_pk${idx}_values = [...new Set(records.map(r => r.${fkField}).filter(v => v !== null && v !== undefined))];`
+      );
+    });
+    const whereEntries = pkFields.map((pk, idx) => `${pk}: { in: ${field.name}_pk${idx}_values }`).join(", ");
+    writer
+      .writeLine(`const ${field.name}_related = await this.client.${toCamelCase(field.type)}.findMany(`)
+      .block(() => {
+        writer
+          .writeLine(`...${field.name}_opts,`)
+          .writeLine(
+            `...(${field.name}_keysToInject.length > 0 ? { select: { ...${field.name}_sel, ...Object.fromEntries(${field.name}_keysToInject.map(k => [k, true])) } } : {}),`
+          )
+          .writeLine(`where: { ${whereEntries} }`);
+      })
+      .writeLine(`, { tx });`);
+  }
+
+  writer
+    .writeLine(`${field.name}_hashMap = new Map(${field.name}_related.map((r) =>`)
+    .block(() => {
+      writer
+        .writeLine(`const _r = r as Record<string, unknown>;`)
+        .writeLine(`const key = ${mapKeyExpr};`)
+        .writeLine(
+          `const value = ${field.name}_keysToInject.length > 0 ? Object.fromEntries(Object.entries(_r).filter(([k]) => !${field.name}_keysToInject.includes(k))) : _r;`
+        )
+        .writeLine(`return [key, value as unknown];`);
+    })
+    .writeLine(`));`);
+}
+
+/**
+ * Type B: FK lives on the OTHER model, but this side is singular (1-to-1 inverse).
+ * e.g. User.profile where Profile.userId is the FK.
+ * Batch-fetch by FK = parentPK, map key = JSON.stringify(related FK value).
+ */
+function buildTypeBHashMap(writer: CodeBlockWriter, field: Field, otherField: Field) {
+  const fkFields = otherField.relationFromFields!; // FK fields on the related model
+  const pkFields = otherField.relationToFields!; // PK fields on THIS model
+
+  emitKeyInjectionSetup(writer, field.name, fkFields);
+
+  const mapKeyExpr =
+    fkFields.length === 1
+      ? `JSON.stringify(_r["${fkFields[0]}"])`
+      : `JSON.stringify([${fkFields.map((f) => `_r["${f}"]`).join(", ")}])`;
+
+  if (pkFields.length === 1) {
+    writer.writeLine(`const ${field.name}_parentIds = [...new Set(records.map(r => r.${pkFields[0]}))];`);
+    writer
+      .writeLine(`const ${field.name}_related = await this.client.${toCamelCase(field.type)}.findMany(`)
+      .block(() => {
+        writer
+          .writeLine(`...${field.name}_opts,`)
+          .writeLine(
+            `...(${field.name}_keysToInject.length > 0 ? { select: { ...${field.name}_sel, ...Object.fromEntries(${field.name}_keysToInject.map(k => [k, true])) } } : {}),`
+          )
+          .writeLine(`where: { ${fkFields[0]}: { in: ${field.name}_parentIds } }`);
+      })
+      .writeLine(`, { tx });`);
+  } else {
+    pkFields.forEach((pkField, idx) => {
+      writer.writeLine(`const ${field.name}_pk${idx}_values = [...new Set(records.map(r => r.${pkField}))];`);
+    });
+    const whereEntries = fkFields.map((fk, idx) => `${fk}: { in: ${field.name}_pk${idx}_values }`).join(", ");
+    writer
+      .writeLine(`const ${field.name}_related = await this.client.${toCamelCase(field.type)}.findMany(`)
+      .block(() => {
+        writer
+          .writeLine(`...${field.name}_opts,`)
+          .writeLine(
+            `...(${field.name}_keysToInject.length > 0 ? { select: { ...${field.name}_sel, ...Object.fromEntries(${field.name}_keysToInject.map(k => [k, true])) } } : {}),`
+          )
+          .writeLine(`where: { ${whereEntries} }`);
+      })
+      .writeLine(`, { tx });`);
+  }
+
+  writer
+    .writeLine(`${field.name}_hashMap = new Map(${field.name}_related.map((r) =>`)
+    .block(() => {
+      writer
+        .writeLine(`const _r = r as Record<string, unknown>;`)
+        .writeLine(`const key = ${mapKeyExpr};`)
+        .writeLine(
+          `const value = ${field.name}_keysToInject.length > 0 ? Object.fromEntries(Object.entries(_r).filter(([k]) => !${field.name}_keysToInject.includes(k))) : _r;`
+        )
+        .writeLine(`return [key, value as unknown];`);
+    })
+    .writeLine(`));`);
+}
+
+/**
+ * Type C: 1-to-many (FK on the OTHER/child model, this field is a list).
+ * e.g. User.posts where Post.authorId is the FK.
+ * Batch-fetch all children, group by FK value, apply take/skip per group.
+ */
+function buildTypeCHashMap(writer: CodeBlockWriter, field: Field, otherField: Field) {
+  const fkFields = otherField.relationFromFields!; // FK fields on child model
+  const pkFields = otherField.relationToFields!; // PK fields on this (parent) model
+
+  emitKeyInjectionSetup(writer, field.name, fkFields);
+
+  const mapKeyExpr =
+    fkFields.length === 1
+      ? `JSON.stringify(_r["${fkFields[0]}"])`
+      : `JSON.stringify([${fkFields.map((f) => `_r["${f}"]`).join(", ")}])`;
+
+  // Batch fetch – strip take/skip so they can be applied per group below
+  if (pkFields.length === 1) {
+    writer.writeLine(`const ${field.name}_parentIds = [...new Set(records.map(r => r.${pkFields[0]}))];`);
+    writer
+      .writeLine(`const ${field.name}_allRelated = await this.client.${toCamelCase(field.type)}.findMany(`)
+      .block(() => {
+        writer
+          .writeLine(`...${field.name}_opts,`)
+          .writeLine(
+            `...(${field.name}_keysToInject.length > 0 ? { select: { ...${field.name}_sel, ...Object.fromEntries(${field.name}_keysToInject.map(k => [k, true])) } } : {}),`
+          )
+          .writeLine(`take: undefined,`)
+          .writeLine(`skip: undefined,`)
+          .writeLine(`where: { ${fkFields[0]}: { in: ${field.name}_parentIds } }`);
+      })
+      .writeLine(`, { tx });`);
+  } else {
+    pkFields.forEach((pk, idx) => {
+      writer.writeLine(`const ${field.name}_pk${idx}_values = [...new Set(records.map(r => r.${pk}))];`);
+    });
+    const whereEntries = fkFields.map((fk, idx) => `${fk}: { in: ${field.name}_pk${idx}_values }`).join(", ");
+    writer
+      .writeLine(`const ${field.name}_allRelated = await this.client.${toCamelCase(field.type)}.findMany(`)
+      .block(() => {
+        writer
+          .writeLine(`...${field.name}_opts,`)
+          .writeLine(
+            `...(${field.name}_keysToInject.length > 0 ? { select: { ...${field.name}_sel, ...Object.fromEntries(${field.name}_keysToInject.map(k => [k, true])) } } : {}),`
+          )
+          .writeLine(`take: undefined,`)
+          .writeLine(`skip: undefined,`)
+          .writeLine(`where: { ${whereEntries} }`);
+      })
+      .writeLine(`, { tx });`);
+  }
+
+  // Capture take/skip for per-group slicing
+  writer
+    .writeLine(
+      `const ${field.name}_take = attach_${field.name} !== true ? (attach_${field.name} as Prisma.${field.type}FindManyArgs).take : undefined;`
+    )
+    .writeLine(
+      `const ${field.name}_skip = attach_${field.name} !== true ? (attach_${field.name} as Prisma.${field.type}FindManyArgs).skip : undefined;`
+    );
+
+  // Build hash map: FK value → children[]
+  writer
+    .writeLine(`${field.name}_hashMap = new Map<string, unknown[]>();`)
+    .writeLine(`for (const related of ${field.name}_allRelated)`)
+    .block(() => {
+      writer
+        .writeLine(`const _r = related as Record<string, unknown>;`)
+        .writeLine(`const key = ${mapKeyExpr};`)
+        .writeLine(`if (!${field.name}_hashMap!.has(key)) ${field.name}_hashMap!.set(key, []);`)
+        .writeLine(
+          `const value = ${field.name}_keysToInject.length > 0 ? Object.fromEntries(Object.entries(_r).filter(([k]) => !${field.name}_keysToInject.includes(k))) : _r;`
+        )
+        .writeLine(`${field.name}_hashMap!.get(key)!.push(value as unknown);`);
+    });
+
+  // Apply take/skip per group
+  writer.writeLine(`if (${field.name}_skip !== undefined || ${field.name}_take !== undefined)`).block(() => {
+    writer.writeLine(`for (const [key, group] of ${field.name}_hashMap!)`).block(() => {
+      writer
+        .writeLine(`const start = ${field.name}_skip ?? 0;`)
+        .writeLine(`const end = ${field.name}_take !== undefined ? start + ${field.name}_take : undefined;`)
+        .writeLine(`${field.name}_hashMap!.set(key, group.slice(start, end));`);
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// ASSIGN PHASE: synchronous map over records using pre-built hash maps
+// ---------------------------------------------------------------------------
+
+function addHashJoinAssignPhase(writer: CodeBlockWriter, model: Model, models: readonly Model[]) {
   const relationFields = model.fields.filter(({ kind }) => kind === "object");
   const allFields = models.flatMap(({ fields }) => fields);
 
   writer
-    .writeLine("const recordsWithRelations = records.map(async (record) => ")
+    .writeLine("const recordsWithRelations = records.map((record) =>")
     .block(() => {
       writer.writeLine("const unsafeRecord = record as Record<string, unknown>;");
       relationFields.forEach((field) => {
-        writer
-          .write(`const attach_${field.name} = `)
-          .write(`query.select?.${field.name} || query.include?.${field.name};`)
-          .writeLine(`if (attach_${field.name})`)
-          .block(() => {
-            const otherFieldOfRelation = allFields.find(
-              (_field) => _field.relationName === field.relationName && field !== _field
-            )!;
-            handleVariousRelationships(writer, field, otherFieldOfRelation, models);
-          });
+        const otherField = allFields.find((_field) => _field.relationName === field.relationName && field !== _field)!;
+        writer.writeLine(`if (attach_${field.name})`).block(() => {
+          if (!field.isList) {
+            if (field.relationFromFields?.length) {
+              assignTypeARecord(writer, field);
+            } else {
+              assignTypeBRecord(writer, field, otherField);
+            }
+          } else {
+            assignTypeCRecords(writer, field, otherField);
+          }
+        });
       });
       writer.writeLine("return unsafeRecord;");
     })
     .writeLine(");");
 }
 
-function handleVariousRelationships(
-  writer: CodeBlockWriter,
-  field: Field,
-  otherField: Field,
-  models: readonly Model[]
-) {
-  if (!field.isList) {
-    if (field.relationFromFields?.length) {
-      addOneToOneMetaOnFieldRelation(writer, field, models);
-    } else {
-      addOneToOneMetaOnOtherFieldRelation(writer, field, otherField);
-    }
+function assignTypeARecord(writer: CodeBlockWriter, field: Field) {
+  const fkFields = field.relationFromFields!;
+  const lookupKey =
+    fkFields.length === 1
+      ? `JSON.stringify(record.${fkFields[0]})`
+      : `JSON.stringify([${fkFields.map((f) => `record.${f}`).join(", ")}])`;
+
+  if (!field.isRequired) {
+    writer.writeLine(
+      `unsafeRecord['${field.name}'] = record.${fkFields[0]} === null ? null : (${field.name}_hashMap!.get(${lookupKey}) ?? null);`
+    );
   } else {
-    addOneToManyRelation(writer, field, otherField);
+    writer.writeLine(`unsafeRecord['${field.name}'] = ${field.name}_hashMap!.get(${lookupKey}) ?? null;`);
   }
 }
 
-function addOneToOneMetaOnFieldRelation(writer: CodeBlockWriter, field: Field, models: readonly Model[]) {
-  const otherModel = models.find(({ name }) => name === field.type)!;
-  const otherModelKeyPath = JSON.parse(getUniqueIdentifiers(otherModel)[0].keyPath) as string[];
+function assignTypeBRecord(writer: CodeBlockWriter, field: Field, otherField: Field) {
+  const pkFields = otherField.relationToFields!;
+  const lookupKey =
+    pkFields.length === 1
+      ? `JSON.stringify(record.${pkFields[0]})`
+      : `JSON.stringify([${pkFields.map((f) => `record.${f}`).join(", ")}])`;
 
-  const compositeKeyName = otherModelKeyPath.join("_");
-  const compositeKey = otherModelKeyPath
-    .map((toField) => `${toField}: record.${field.relationFromFields?.at(field.relationToFields!.indexOf(toField))}!`)
-    .join(", ");
-
-  writer
-    .write(`unsafeRecord['${field.name}'] = `)
-    .conditionalWrite(!field.isRequired, () => `record.${field.relationFromFields?.at(0)} === null ? null :`)
-    .writeLine(`await this.client.${toCamelCase(field.type)}.findUnique(`)
-    .block(() => {
-      writer.writeLine(`...(attach_${field.name} === true ? {} : attach_${field.name}),`);
-      if (field.relationFromFields?.length === 1) {
-        writer.writeLine(`where: { ${compositeKey} }`);
-      } else {
-        writer.writeLine(`where: { ${compositeKeyName}: { ${compositeKey} } }`);
-      }
-    })
-    .writeLine(`, { tx })`);
+  writer.writeLine(`unsafeRecord['${field.name}'] = ${field.name}_hashMap!.get(${lookupKey}) ?? null;`);
 }
 
-function addOneToOneMetaOnOtherFieldRelation(writer: CodeBlockWriter, field: Field, otherField: Field) {
-  const compositeKeyName = otherField.relationFromFields!.join("_");
-  const compositeKey = otherField
-    .relationFromFields!.map((fromField, idx) => `${fromField}: record.${otherField.relationToFields?.at(idx)}`)
-    .join(", ");
+function assignTypeCRecords(writer: CodeBlockWriter, field: Field, otherField: Field) {
+  const pkFields = otherField.relationToFields!;
+  const lookupKey =
+    pkFields.length === 1
+      ? `JSON.stringify(record.${pkFields[0]})`
+      : `JSON.stringify([${pkFields.map((f) => `record.${f}`).join(", ")}])`;
 
-  writer
-    .writeLine(`unsafeRecord['${field.name}'] = await this.client.${toCamelCase(field.type)}.findUnique(`)
-    .block(() => {
-      writer.writeLine(`...(attach_${field.name} === true ? {} : attach_${field.name}),`);
-      if (otherField.relationFromFields?.length === 1) {
-        writer.writeLine(`where: { ${compositeKey} }`);
-      } else {
-        writer.writeLine(`where: { ${compositeKeyName}: { ${compositeKey} } }`);
-      }
-    })
-    .writeLine(`, { tx })`);
-}
-
-function addOneToManyRelation(writer: CodeBlockWriter, field: Field, otherField: Field) {
-  const fkMapping = otherField
-    .relationFromFields!.map((fromField, idx) => `${fromField}: record.${otherField.relationToFields?.at(idx)}!`)
-    .join(", ");
-
-  writer
-    .writeLine(`unsafeRecord['${field.name}'] = await this.client.${toCamelCase(field.type)}.findMany(`)
-    .block(() => {
-      writer
-        .writeLine(`...(attach_${field.name} === true ? {} : attach_${field.name}),`)
-        .writeLine(`where: { ${fkMapping} }`);
-    })
-    .writeLine(`, { tx })`);
+  writer.writeLine(`unsafeRecord['${field.name}'] = ${field.name}_hashMap!.get(${lookupKey}) ?? [];`);
 }
 
 function addReturn(writer: CodeBlockWriter, model: Model) {
   writer
-    .write(`return (await Promise.all(recordsWithRelations)) as `)
+    .write(`return recordsWithRelations as `)
     .write(`Prisma.Result<Prisma.${model.name}Delegate, Q, 'findFirstOrThrow'>[];`);
 }

--- a/packages/generator/src/fileCreators/prisma-idb-client/classes/models/utils/_applyRelations.ts
+++ b/packages/generator/src/fileCreators/prisma-idb-client/classes/models/utils/_applyRelations.ts
@@ -10,6 +10,8 @@ export function addApplyRelations(writer: CodeBlockWriter, model: Model, models:
     .writeLine(`query?: Q): Promise<Prisma.Result<Prisma.${model.name}Delegate, Q, 'findFirstOrThrow'>[]>`)
     .block(() => {
       addEarlyExit(writer, model);
+      addAttachFlags(writer, model);
+      addNoRelationsEarlyExit(writer, model);
       addHashJoinBuildPhase(writer, model, models);
       addHashJoinAssignPhase(writer, model, models);
       addReturn(writer, model);
@@ -19,6 +21,29 @@ export function addApplyRelations(writer: CodeBlockWriter, model: Model, models:
 function addEarlyExit(writer: CodeBlockWriter, model: Model) {
   writer.writeLine(
     `if (!query) return records as Prisma.Result<Prisma.${model.name}Delegate, Q, 'findFirstOrThrow'>[];`
+  );
+}
+
+/**
+ * Hoist `attach_<relation>` flags above the build phase so we can short-circuit
+ * the entire body when no relations are being attached. Without this, every
+ * `findMany` (even ones with no `select`/`include`) pays the cost of `records.map`
+ * over potentially thousands of records, plus the larger function body
+ * impedes V8 inlining for the hot path.
+ */
+function addAttachFlags(writer: CodeBlockWriter, model: Model) {
+  const relationFields = model.fields.filter(({ kind }) => kind === "object");
+  for (const field of relationFields) {
+    writer.writeLine(`const attach_${field.name} = query.select?.${field.name} || query.include?.${field.name};`);
+  }
+}
+
+function addNoRelationsEarlyExit(writer: CodeBlockWriter, model: Model) {
+  const relationFields = model.fields.filter(({ kind }) => kind === "object");
+  if (relationFields.length === 0) return;
+  const condition = relationFields.map((f) => `!attach_${f.name}`).join(" && ");
+  writer.writeLine(
+    `if (${condition}) return records as Prisma.Result<Prisma.${model.name}Delegate, Q, 'findFirstOrThrow'>[];`
   );
 }
 
@@ -32,8 +57,6 @@ function addHashJoinBuildPhase(writer: CodeBlockWriter, model: Model, models: re
 
   relationFields.forEach((field) => {
     const otherField = allFields.find((_field) => _field.relationName === field.relationName && field !== _field)!;
-
-    writer.writeLine(`const attach_${field.name} = query.select?.${field.name} || query.include?.${field.name};`);
 
     const mapValueType = field.isList ? "unknown[]" : "unknown";
     writer.writeLine(`let ${field.name}_hashMap: Map<string, ${mapValueType}> | undefined;`);

--- a/packages/generator/src/fileCreators/prisma-idb-client/classes/models/utils/_applyRelations.ts
+++ b/packages/generator/src/fileCreators/prisma-idb-client/classes/models/utils/_applyRelations.ts
@@ -71,6 +71,43 @@ function emitKeyInjectionSetup(writer: CodeBlockWriter, fieldName: string, keyFi
 }
 
 /**
+ * Emits the spread-expression that re-applies `select` with injected key fields,
+ * preserving the user's original select shape but ensuring required key fields are fetched.
+ */
+function selectInjectionSpread(fieldName: string): string {
+  return `...(${fieldName}_keysToInject.length > 0 ? { select: { ...${fieldName}_sel, ...Object.fromEntries(${fieldName}_keysToInject.map(k => [k, true])) } } : {})`;
+}
+
+/**
+ * Emits the merged `where` clause: the user's nested where (if any) AND-ed with the FK predicate.
+ * Assumes a `${fieldName}_userWhere` variable is already in scope (declared via either this helper
+ * with `declareUserWhere=true` or hoisted manually for branching control flow).
+ * Produces `_fkWhere` and `_where` (and optionally `_userWhere`).
+ */
+function emitWhereMerge(
+  writer: CodeBlockWriter,
+  fieldName: string,
+  fkWhereExpr: string,
+  declareUserWhere: boolean = true
+) {
+  if (declareUserWhere) {
+    writer.writeLine(`const ${fieldName}_userWhere = ${fieldName}_opts.where as Record<string, unknown> | undefined;`);
+  }
+  writer
+    .writeLine(`const ${fieldName}_fkWhere = ${fkWhereExpr};`)
+    .writeLine(
+      `const ${fieldName}_where = ${fieldName}_userWhere ? { AND: [${fieldName}_userWhere, ${fieldName}_fkWhere] } : ${fieldName}_fkWhere;`
+    );
+}
+
+/**
+ * Emits an expression that strips injected key fields from a record (or returns it as-is).
+ */
+function strippedValueExpr(fieldName: string, recordVar: string): string {
+  return `${fieldName}_keysToInject.length > 0 ? Object.fromEntries(Object.entries(${recordVar}).filter(([k]) => !${fieldName}_keysToInject.includes(k))) : ${recordVar}`;
+}
+
+/**
  * Type A: FK lives on THIS model (e.g. Post.authorId → User.id).
  * Batch-fetch the related model by PK, map key = JSON.stringify(related PK).
  */
@@ -85,41 +122,33 @@ function buildTypeAHashMap(writer: CodeBlockWriter, field: Field) {
       ? `JSON.stringify(_r["${pkFields[0]}"])`
       : `JSON.stringify([${pkFields.map((f) => `_r["${f}"]`).join(", ")}])`;
 
+  let fkWhereExpr: string;
   if (fkFields.length === 1) {
     writer.writeLine(
       `const ${field.name}_fkValues = [...new Set(records.map(r => r.${fkFields[0]}).filter(v => v !== null && v !== undefined))];`
     );
-    writer
-      .writeLine(`const ${field.name}_related = await this.client.${toCamelCase(field.type)}.findMany(`)
-      .block(() => {
-        writer
-          .writeLine(`...${field.name}_opts,`)
-          .writeLine(
-            `...(${field.name}_keysToInject.length > 0 ? { select: { ...${field.name}_sel, ...Object.fromEntries(${field.name}_keysToInject.map(k => [k, true])) } } : {}),`
-          )
-          .writeLine(`where: { ${pkFields[0]}: { in: ${field.name}_fkValues } }`);
-      })
-      .writeLine(`, { tx });`);
+    fkWhereExpr = `{ ${pkFields[0]}: { in: ${field.name}_fkValues } }`;
   } else {
-    // composite FK – collect per-component value sets for the IN filter
     fkFields.forEach((fkField, idx) => {
       writer.writeLine(
         `const ${field.name}_pk${idx}_values = [...new Set(records.map(r => r.${fkField}).filter(v => v !== null && v !== undefined))];`
       );
     });
     const whereEntries = pkFields.map((pk, idx) => `${pk}: { in: ${field.name}_pk${idx}_values }`).join(", ");
-    writer
-      .writeLine(`const ${field.name}_related = await this.client.${toCamelCase(field.type)}.findMany(`)
-      .block(() => {
-        writer
-          .writeLine(`...${field.name}_opts,`)
-          .writeLine(
-            `...(${field.name}_keysToInject.length > 0 ? { select: { ...${field.name}_sel, ...Object.fromEntries(${field.name}_keysToInject.map(k => [k, true])) } } : {}),`
-          )
-          .writeLine(`where: { ${whereEntries} }`);
-      })
-      .writeLine(`, { tx });`);
+    fkWhereExpr = `{ ${whereEntries} }`;
   }
+
+  emitWhereMerge(writer, field.name, fkWhereExpr);
+
+  writer
+    .writeLine(`const ${field.name}_related = await this.client.${toCamelCase(field.type)}.findMany(`)
+    .block(() => {
+      writer
+        .writeLine(`...${field.name}_opts,`)
+        .writeLine(`${selectInjectionSpread(field.name)},`)
+        .writeLine(`where: ${field.name}_where`);
+    })
+    .writeLine(`, { tx });`);
 
   writer
     .writeLine(`${field.name}_hashMap = new Map(${field.name}_related.map((r) =>`)
@@ -127,9 +156,7 @@ function buildTypeAHashMap(writer: CodeBlockWriter, field: Field) {
       writer
         .writeLine(`const _r = r as Record<string, unknown>;`)
         .writeLine(`const key = ${mapKeyExpr};`)
-        .writeLine(
-          `const value = ${field.name}_keysToInject.length > 0 ? Object.fromEntries(Object.entries(_r).filter(([k]) => !${field.name}_keysToInject.includes(k))) : _r;`
-        )
+        .writeLine(`const value = ${strippedValueExpr(field.name, "_r")};`)
         .writeLine(`return [key, value as unknown];`);
     })
     .writeLine(`));`);
@@ -151,36 +178,29 @@ function buildTypeBHashMap(writer: CodeBlockWriter, field: Field, otherField: Fi
       ? `JSON.stringify(_r["${fkFields[0]}"])`
       : `JSON.stringify([${fkFields.map((f) => `_r["${f}"]`).join(", ")}])`;
 
+  let fkWhereExpr: string;
   if (pkFields.length === 1) {
     writer.writeLine(`const ${field.name}_parentIds = [...new Set(records.map(r => r.${pkFields[0]}))];`);
-    writer
-      .writeLine(`const ${field.name}_related = await this.client.${toCamelCase(field.type)}.findMany(`)
-      .block(() => {
-        writer
-          .writeLine(`...${field.name}_opts,`)
-          .writeLine(
-            `...(${field.name}_keysToInject.length > 0 ? { select: { ...${field.name}_sel, ...Object.fromEntries(${field.name}_keysToInject.map(k => [k, true])) } } : {}),`
-          )
-          .writeLine(`where: { ${fkFields[0]}: { in: ${field.name}_parentIds } }`);
-      })
-      .writeLine(`, { tx });`);
+    fkWhereExpr = `{ ${fkFields[0]}: { in: ${field.name}_parentIds } }`;
   } else {
     pkFields.forEach((pkField, idx) => {
       writer.writeLine(`const ${field.name}_pk${idx}_values = [...new Set(records.map(r => r.${pkField}))];`);
     });
     const whereEntries = fkFields.map((fk, idx) => `${fk}: { in: ${field.name}_pk${idx}_values }`).join(", ");
-    writer
-      .writeLine(`const ${field.name}_related = await this.client.${toCamelCase(field.type)}.findMany(`)
-      .block(() => {
-        writer
-          .writeLine(`...${field.name}_opts,`)
-          .writeLine(
-            `...(${field.name}_keysToInject.length > 0 ? { select: { ...${field.name}_sel, ...Object.fromEntries(${field.name}_keysToInject.map(k => [k, true])) } } : {}),`
-          )
-          .writeLine(`where: { ${whereEntries} }`);
-      })
-      .writeLine(`, { tx });`);
+    fkWhereExpr = `{ ${whereEntries} }`;
   }
+
+  emitWhereMerge(writer, field.name, fkWhereExpr);
+
+  writer
+    .writeLine(`const ${field.name}_related = await this.client.${toCamelCase(field.type)}.findMany(`)
+    .block(() => {
+      writer
+        .writeLine(`...${field.name}_opts,`)
+        .writeLine(`${selectInjectionSpread(field.name)},`)
+        .writeLine(`where: ${field.name}_where`);
+    })
+    .writeLine(`, { tx });`);
 
   writer
     .writeLine(`${field.name}_hashMap = new Map(${field.name}_related.map((r) =>`)
@@ -188,9 +208,7 @@ function buildTypeBHashMap(writer: CodeBlockWriter, field: Field, otherField: Fi
       writer
         .writeLine(`const _r = r as Record<string, unknown>;`)
         .writeLine(`const key = ${mapKeyExpr};`)
-        .writeLine(
-          `const value = ${field.name}_keysToInject.length > 0 ? Object.fromEntries(Object.entries(_r).filter(([k]) => !${field.name}_keysToInject.includes(k))) : _r;`
-        )
+        .writeLine(`const value = ${strippedValueExpr(field.name, "_r")};`)
         .writeLine(`return [key, value as unknown];`);
     })
     .writeLine(`));`);
@@ -199,7 +217,13 @@ function buildTypeBHashMap(writer: CodeBlockWriter, field: Field, otherField: Fi
 /**
  * Type C: 1-to-many (FK on the OTHER/child model, this field is a list).
  * e.g. User.posts where Post.authorId is the FK.
- * Batch-fetch all children, group by FK value, apply take/skip per group.
+ *
+ * Two execution paths:
+ *  - **Fast path (batch)**: one `findMany` for all parents, group by FK in JS, slice take/skip per group.
+ *    User-supplied `where` is merged with the FK predicate via AND.
+ *  - **Fallback (per-parent)**: when `cursor` or `distinct` is present on the relation, those options
+ *    cannot be soundly applied across all parents in a single query, so we fall back to one
+ *    `findMany` per parent. This sacrifices the batch optimisation only for those uncommon cases.
  */
 function buildTypeCHashMap(writer: CodeBlockWriter, field: Field, otherField: Field) {
   const fkFields = otherField.relationFromFields!; // FK fields on child model
@@ -207,78 +231,149 @@ function buildTypeCHashMap(writer: CodeBlockWriter, field: Field, otherField: Fi
 
   emitKeyInjectionSetup(writer, field.name, fkFields);
 
-  const mapKeyExpr =
+  const groupKeyExpr =
     fkFields.length === 1
       ? `JSON.stringify(_r["${fkFields[0]}"])`
       : `JSON.stringify([${fkFields.map((f) => `_r["${f}"]`).join(", ")}])`;
 
-  // Batch fetch – strip take/skip so they can be applied per group below
+  // Capture take/skip/cursor/distinct from the user's options.
+  writer
+    .writeLine(`const ${field.name}_take = ${field.name}_opts.take as number | undefined;`)
+    .writeLine(`const ${field.name}_skip = ${field.name}_opts.skip as number | undefined;`)
+    .writeLine(`const ${field.name}_cursor = ${field.name}_opts.cursor;`)
+    .writeLine(`const ${field.name}_distinct = ${field.name}_opts.distinct;`);
+
+  // Compute parent ID buckets once (used by both code paths).
   if (pkFields.length === 1) {
     writer.writeLine(`const ${field.name}_parentIds = [...new Set(records.map(r => r.${pkFields[0]}))];`);
-    writer
-      .writeLine(`const ${field.name}_allRelated = await this.client.${toCamelCase(field.type)}.findMany(`)
-      .block(() => {
-        writer
-          .writeLine(`...${field.name}_opts,`)
-          .writeLine(
-            `...(${field.name}_keysToInject.length > 0 ? { select: { ...${field.name}_sel, ...Object.fromEntries(${field.name}_keysToInject.map(k => [k, true])) } } : {}),`
-          )
-          .writeLine(`take: undefined,`)
-          .writeLine(`skip: undefined,`)
-          .writeLine(`where: { ${fkFields[0]}: { in: ${field.name}_parentIds } }`);
-      })
-      .writeLine(`, { tx });`);
   } else {
     pkFields.forEach((pk, idx) => {
       writer.writeLine(`const ${field.name}_pk${idx}_values = [...new Set(records.map(r => r.${pk}))];`);
     });
-    const whereEntries = fkFields.map((fk, idx) => `${fk}: { in: ${field.name}_pk${idx}_values }`).join(", ");
-    writer
-      .writeLine(`const ${field.name}_allRelated = await this.client.${toCamelCase(field.type)}.findMany(`)
-      .block(() => {
-        writer
-          .writeLine(`...${field.name}_opts,`)
-          .writeLine(
-            `...(${field.name}_keysToInject.length > 0 ? { select: { ...${field.name}_sel, ...Object.fromEntries(${field.name}_keysToInject.map(k => [k, true])) } } : {}),`
-          )
-          .writeLine(`take: undefined,`)
-          .writeLine(`skip: undefined,`)
-          .writeLine(`where: { ${whereEntries} }`);
-      })
-      .writeLine(`, { tx });`);
   }
 
-  // Capture take/skip for per-group slicing
-  writer
-    .writeLine(
-      `const ${field.name}_take = attach_${field.name} !== true ? (attach_${field.name} as Prisma.${field.type}FindManyArgs).take : undefined;`
-    )
-    .writeLine(
-      `const ${field.name}_skip = attach_${field.name} !== true ? (attach_${field.name} as Prisma.${field.type}FindManyArgs).skip : undefined;`
-    );
+  writer.writeLine(`${field.name}_hashMap = new Map<string, unknown[]>();`);
 
-  // Build hash map: FK value → children[]
+  // Capture user where once at the outer scope so both code paths can AND-merge with it.
+  writer.writeLine(`const ${field.name}_userWhere = ${field.name}_opts.where as Record<string, unknown> | undefined;`);
+
+  // ---- Fallback path: per-parent loop when cursor or distinct is present. ----
   writer
-    .writeLine(`${field.name}_hashMap = new Map<string, unknown[]>();`)
-    .writeLine(`for (const related of ${field.name}_allRelated)`)
+    .writeLine(`if (${field.name}_cursor !== undefined || ${field.name}_distinct !== undefined)`)
+    .block(() => {
+      emitTypeCPerParentFallback(writer, field, otherField);
+    })
+    .writeLine(`else`)
+    .block(() => {
+      emitTypeCBatchPath(writer, field, fkFields, pkFields, groupKeyExpr);
+    });
+}
+
+function emitTypeCPerParentFallback(writer: CodeBlockWriter, field: Field, otherField: Field) {
+  const fkFields = otherField.relationFromFields!;
+  const pkFields = otherField.relationToFields!;
+
+  if (pkFields.length === 1) {
+    writer.writeLine(`for (const parentId of ${field.name}_parentIds)`).block(() => {
+      writer
+        .writeLine(`const ${field.name}_perParentFkWhere = { ${fkFields[0]}: parentId };`)
+        .writeLine(
+          `const ${field.name}_perParentWhere = ${field.name}_userWhere ? { AND: [${field.name}_userWhere, ${field.name}_perParentFkWhere] } : ${field.name}_perParentFkWhere;`
+        )
+        .writeLine(`const children = await this.client.${toCamelCase(field.type)}.findMany(`)
+        .block(() => {
+          writer
+            .writeLine(`...${field.name}_opts,`)
+            .writeLine(`${selectInjectionSpread(field.name)},`)
+            .writeLine(`where: ${field.name}_perParentWhere`);
+        })
+        .writeLine(`, { tx });`)
+        .writeLine(`const stripped = children.map((c) =>`)
+        .block(() => {
+          writer
+            .writeLine(`const _r = c as Record<string, unknown>;`)
+            .writeLine(`return ${strippedValueExpr(field.name, "_r")};`);
+        })
+        .writeLine(`);`)
+        .writeLine(`${field.name}_hashMap!.set(JSON.stringify(parentId), stripped as unknown[]);`);
+    });
+  } else {
+    // Composite parent PK: zip the per-component arrays back into per-parent tuples.
+    writer.writeLine(`for (const parent of records)`).block(() => {
+      const fkAssignments = fkFields.map((fk, idx) => `${fk}: parent.${pkFields[idx]}`).join(", ");
+      const keyParts = pkFields.map((p) => `parent.${p}`).join(", ");
+      writer
+        .writeLine(`const ${field.name}_perParentFkWhere = { ${fkAssignments} };`)
+        .writeLine(
+          `const ${field.name}_perParentWhere = ${field.name}_userWhere ? { AND: [${field.name}_userWhere, ${field.name}_perParentFkWhere] } : ${field.name}_perParentFkWhere;`
+        )
+        .writeLine(`const children = await this.client.${toCamelCase(field.type)}.findMany(`)
+        .block(() => {
+          writer
+            .writeLine(`...${field.name}_opts,`)
+            .writeLine(`${selectInjectionSpread(field.name)},`)
+            .writeLine(`where: ${field.name}_perParentWhere`);
+        })
+        .writeLine(`, { tx });`)
+        .writeLine(`const stripped = children.map((c) =>`)
+        .block(() => {
+          writer
+            .writeLine(`const _r = c as Record<string, unknown>;`)
+            .writeLine(`return ${strippedValueExpr(field.name, "_r")};`);
+        })
+        .writeLine(`);`)
+        .writeLine(`${field.name}_hashMap!.set(JSON.stringify([${keyParts}]), stripped as unknown[]);`);
+    });
+  }
+}
+
+function emitTypeCBatchPath(
+  writer: CodeBlockWriter,
+  field: Field,
+  fkFields: readonly string[],
+  pkFields: readonly string[],
+  groupKeyExpr: string
+) {
+  const fkWhereExpr =
+    pkFields.length === 1
+      ? `{ ${fkFields[0]}: { in: ${field.name}_parentIds } }`
+      : `{ ${fkFields.map((fk, idx) => `${fk}: { in: ${field.name}_pk${idx}_values }`).join(", ")} }`;
+
+  emitWhereMerge(writer, field.name, fkWhereExpr, false);
+
+  // Strip take/skip — applied per-group below to preserve per-parent semantics.
+  writer
+    .writeLine(`const ${field.name}_allRelated = await this.client.${toCamelCase(field.type)}.findMany(`)
     .block(() => {
       writer
-        .writeLine(`const _r = related as Record<string, unknown>;`)
-        .writeLine(`const key = ${mapKeyExpr};`)
-        .writeLine(`if (!${field.name}_hashMap!.has(key)) ${field.name}_hashMap!.set(key, []);`)
-        .writeLine(
-          `const value = ${field.name}_keysToInject.length > 0 ? Object.fromEntries(Object.entries(_r).filter(([k]) => !${field.name}_keysToInject.includes(k))) : _r;`
-        )
-        .writeLine(`${field.name}_hashMap!.get(key)!.push(value as unknown);`);
-    });
+        .writeLine(`...${field.name}_opts,`)
+        .writeLine(`${selectInjectionSpread(field.name)},`)
+        .writeLine(`take: undefined,`)
+        .writeLine(`skip: undefined,`)
+        .writeLine(`where: ${field.name}_where`);
+    })
+    .writeLine(`, { tx });`);
 
-  // Apply take/skip per group
+  // Group by FK value.
+  writer.writeLine(`for (const related of ${field.name}_allRelated)`).block(() => {
+    writer
+      .writeLine(`const _r = related as Record<string, unknown>;`)
+      .writeLine(`const key = ${groupKeyExpr};`)
+      .writeLine(`if (!${field.name}_hashMap!.has(key)) ${field.name}_hashMap!.set(key, []);`)
+      .writeLine(`const value = ${strippedValueExpr(field.name, "_r")};`)
+      .writeLine(`${field.name}_hashMap!.get(key)!.push(value as unknown);`);
+  });
+
+  // Apply take/skip per group, mirroring `findMany`'s sign-aware semantics.
   writer.writeLine(`if (${field.name}_skip !== undefined || ${field.name}_take !== undefined)`).block(() => {
     writer.writeLine(`for (const [key, group] of ${field.name}_hashMap!)`).block(() => {
       writer
-        .writeLine(`const start = ${field.name}_skip ?? 0;`)
-        .writeLine(`const end = ${field.name}_take !== undefined ? start + ${field.name}_take : undefined;`)
-        .writeLine(`${field.name}_hashMap!.set(key, group.slice(start, end));`);
+        .writeLine(`let sliced = group;`)
+        .writeLine(`if (${field.name}_skip !== undefined) sliced = sliced.slice(${field.name}_skip);`)
+        .writeLine(
+          `if (${field.name}_take !== undefined) sliced = ${field.name}_take < 0 ? sliced.slice(${field.name}_take) : sliced.slice(0, ${field.name}_take);`
+        )
+        .writeLine(`${field.name}_hashMap!.set(key, sliced);`);
     });
   });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       '@base-ui/react':
         specifier: ^1.4.0
         version: 1.4.0(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(next@16.2.4(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(svelte@5.55.4(@typescript-eslint/types@8.58.2))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -168,7 +171,7 @@ importers:
         version: 3.1.18
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(svelte@5.55.4(@typescript-eslint/types@8.58.2))
+        version: 2.0.1(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(next@16.2.4(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(svelte@5.55.4(@typescript-eslint/types@8.58.2))
       fumadocs-core:
         specifier: ^16.7.16
         version: 16.7.16(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.5))(next@16.2.4(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6)
@@ -241,7 +244,7 @@ importers:
         version: 6.1.16(svelte@5.55.4(@typescript-eslint/types@8.58.2))
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(svelte@5.55.4(@typescript-eslint/types@8.58.2))
+        version: 2.0.1(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(next@16.2.4(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(svelte@5.55.4(@typescript-eslint/types@8.58.2))
       better-auth:
         specifier: ^1.6.5
         version: 1.6.5(d3df8d9b3a2aa48e475a1fdb10a8f074)
@@ -12433,7 +12436,7 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vercel/analytics@2.0.1(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(svelte@5.55.4(@typescript-eslint/types@8.58.2))':
+  '@vercel/analytics@2.0.1(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(next@16.2.4(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(svelte@5.55.4(@typescript-eslint/types@8.58.2))':
     optionalDependencies:
       '@sveltejs/kit': 2.57.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       next: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)

--- a/scripts/benchmark-local.sh
+++ b/scripts/benchmark-local.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# Run the Benchmark Regression workflow locally via `act`.
+#
+# Prerequisites:
+#   • act    – https://github.com/nektos/act  (brew install act)
+#   • Docker – running and accessible from the shell
+#
+# Usage:
+#   pnpm benchmark:local              # compare HEAD against main
+#   pnpm benchmark:local develop      # compare HEAD against develop
+#   pnpm benchmark:local main -- -v   # pass extra flags to act
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+# ── Pre-flight checks ──────────────────────────────────────────────────────
+if ! command -v act &>/dev/null; then
+  echo "Error: 'act' is not installed. Install it with: brew install act" >&2
+  exit 1
+fi
+
+if ! docker info &>/dev/null; then
+  echo "Error: Docker is not running." >&2
+  exit 1
+fi
+
+# ── Parse arguments ────────────────────────────────────────────────────────
+BASE_BRANCH="main"
+ACT_EXTRA_ARGS=()
+SEEN_SEPARATOR=false
+
+for arg in "$@"; do
+  if [[ "$SEEN_SEPARATOR" == true ]]; then
+    ACT_EXTRA_ARGS+=("$arg")
+  elif [[ "$arg" == "--" ]]; then
+    SEEN_SEPARATOR=true
+  else
+    BASE_BRANCH="$arg"
+  fi
+done
+
+# ── Resolve SHAs ──────────────────────────────────────────────────────────
+BASE_SHA="$(git merge-base HEAD "$BASE_BRANCH")"
+HEAD_SHA="$(git rev-parse HEAD)"
+BRANCH="$(git branch --show-current 2>/dev/null || echo "HEAD")"
+
+echo ""
+echo "╭──────────────────────────────────────────────╮"
+echo "│  Local Benchmark Comparison via act           │"
+echo "╰──────────────────────────────────────────────╯"
+echo ""
+echo "  Current : $BRANCH ($HEAD_SHA)"
+echo "  Base    : $BASE_BRANCH ($BASE_SHA)"
+echo ""
+
+# ── Build event payload ───────────────────────────────────────────────────
+# Set head.repo.full_name to a dummy value so it won't match
+# github.repository — this skips the "Publish benchmark PR comment" step
+# which needs a real GITHUB_TOKEN.
+EVENT_FILE="$(mktemp)"
+trap 'rm -f "$EVENT_FILE"' EXIT
+
+cat > "$EVENT_FILE" <<PAYLOAD
+{
+  "pull_request": {
+    "number": 0,
+    "base": { "sha": "$BASE_SHA", "ref": "$BASE_BRANCH" },
+    "head": {
+      "sha": "$HEAD_SHA",
+      "ref": "$BRANCH",
+      "repo": { "full_name": "local/benchmark" }
+    }
+  }
+}
+PAYLOAD
+
+# ── Kill any stale server on the benchmark port ──────────────────────────────
+# act uses --network host, so host-side processes on port 4175 collide with the
+# container's Playwright webServer.
+BENCHMARK_PORT=4175
+if lsof -ti:"$BENCHMARK_PORT" &>/dev/null; then
+  echo "Killing stale process on port ${BENCHMARK_PORT}…"
+  lsof -ti:"$BENCHMARK_PORT" | xargs kill -9 2>/dev/null || true
+  sleep 1
+fi
+
+# ── Persistent caches ────────────────────────────────────────────────────────
+# Mount host directories into the container so Playwright browsers and the pnpm
+# content-addressable store survive across runs.  This cuts ~60-90 s off repeat
+# runs (Playwright re-download) and speeds up pnpm install for the base commit.
+CACHE_DIR="$ROOT/benchmarks/act-cache"
+PLAYWRIGHT_CACHE="$CACHE_DIR/playwright"
+PNPM_STORE="$CACHE_DIR/pnpm-store"
+mkdir -p "$PLAYWRIGHT_CACHE" "$PNPM_STORE"
+
+# ── Run act ───────────────────────────────────────────────────────────────
+echo "Starting act…  (first run pulls the Docker image)"
+echo ""
+
+act pull_request \
+  -W .github/workflows/benchmark.yml \
+  -e "$EVENT_FILE" \
+  --env CI=true \
+  --rm \
+  --artifact-server-path "$ROOT/benchmarks/act-artifacts" \
+  -v "$PLAYWRIGHT_CACHE:/root/.cache/ms-playwright" \
+  -v "$PNPM_STORE:/root/.local/share/pnpm/store" \
+  "${ACT_EXTRA_ARGS[@]+"${ACT_EXTRA_ARGS[@]}"}"
+
+echo ""
+echo "Done. Results are in benchmarks/results/"

--- a/scripts/benchmark-local.sh
+++ b/scripts/benchmark-local.sh
@@ -45,7 +45,8 @@ done
 # ── Resolve SHAs ──────────────────────────────────────────────────────────
 BASE_SHA="$(git merge-base HEAD "$BASE_BRANCH")"
 HEAD_SHA="$(git rev-parse HEAD)"
-BRANCH="$(git branch --show-current 2>/dev/null || echo "HEAD")"
+BRANCH="$(git branch --show-current 2>/dev/null || true)"
+BRANCH="${BRANCH:-HEAD}"
 
 echo ""
 echo "╭──────────────────────────────────────────────╮"
@@ -63,28 +64,38 @@ echo ""
 EVENT_FILE="$(mktemp)"
 trap 'rm -f "$EVENT_FILE"' EXIT
 
-cat > "$EVENT_FILE" <<PAYLOAD
-{
-  "pull_request": {
-    "number": 0,
-    "base": { "sha": "$BASE_SHA", "ref": "$BASE_BRANCH" },
-    "head": {
-      "sha": "$HEAD_SHA",
-      "ref": "$BRANCH",
-      "repo": { "full_name": "local/benchmark" }
-    }
-  }
-}
-PAYLOAD
+BASE_SHA="$BASE_SHA" \
+  BASE_BRANCH="$BASE_BRANCH" \
+  HEAD_SHA="$HEAD_SHA" \
+  BRANCH="$BRANCH" \
+  node <<'NODE' > "$EVENT_FILE"
+const payload = {
+  pull_request: {
+    number: 0,
+    base: { sha: process.env.BASE_SHA, ref: process.env.BASE_BRANCH },
+    head: {
+      sha: process.env.HEAD_SHA,
+      ref: process.env.BRANCH,
+      repo: { full_name: "local/benchmark" },
+    },
+  },
+};
+process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+NODE
 
 # ── Kill any stale server on the benchmark port ──────────────────────────────
 # act uses --network host, so host-side processes on port 4175 collide with the
 # container's Playwright webServer.
 BENCHMARK_PORT=4175
-if lsof -ti:"$BENCHMARK_PORT" &>/dev/null; then
-  echo "Killing stale process on port ${BENCHMARK_PORT}…"
-  lsof -ti:"$BENCHMARK_PORT" | xargs kill -9 2>/dev/null || true
+PORT_PIDS="$(lsof -ti:"$BENCHMARK_PORT" 2>/dev/null || true)"
+if [[ -n "$PORT_PIDS" ]]; then
+  echo "Terminating stale process on port ${BENCHMARK_PORT}..."
+  printf '%s\n' "$PORT_PIDS" | xargs kill 2>/dev/null || true
   sleep 1
+  if lsof -ti:"$BENCHMARK_PORT" &>/dev/null; then
+    echo "Error: port ${BENCHMARK_PORT} is still in use after SIGTERM. Free it manually and retry." >&2
+    exit 1
+  fi
 fi
 
 # ── Persistent caches ────────────────────────────────────────────────────────

--- a/scripts/benchmark-local.sh
+++ b/scripts/benchmark-local.sh
@@ -50,7 +50,7 @@ BRANCH="${BRANCH:-HEAD}"
 
 echo ""
 echo "╭──────────────────────────────────────────────╮"
-echo "│  Local Benchmark Comparison via act           │"
+echo "│  Local Benchmark Comparison via act          │"
 echo "╰──────────────────────────────────────────────╯"
 echo ""
 echo "  Current : $BRANCH ($HEAD_SHA)"
@@ -117,8 +117,7 @@ act pull_request \
   --env CI=true \
   --rm \
   --artifact-server-path "$ROOT/benchmarks/act-artifacts" \
-  -v "$PLAYWRIGHT_CACHE:/root/.cache/ms-playwright" \
-  -v "$PNPM_STORE:/root/.local/share/pnpm/store" \
+  --container-options "-v $PLAYWRIGHT_CACHE:/root/.cache/ms-playwright -v $PNPM_STORE:/root/.local/share/pnpm/store" \
   "${ACT_EXTRA_ARGS[@]+"${ACT_EXTRA_ARGS[@]}"}"
 
 echo ""


### PR DESCRIPTION
## Description

Use proper hash joins instead of individual look-ups reducing time complexity from O(n log m) to O(n + m)

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Existing tests cover this functionality


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Vercel Analytics integration
  * Bootstrap-based statistical analysis for benchmarks with confidence intervals and noise detection
  * Local benchmark testing script

* **Performance**
  * Optimized database relation handling using batch prefetching instead of per-record async queries

* **CI/CD**
  * Restructured benchmark workflow for improved comparison logic
  * Increased default measured runs to 30
<!-- end of auto-generated comment: release notes by coderabbit.ai -->