### PR TITLE
fix: use NPM_CONFIG_PROVENANCE env var for pnpm provenance publishing

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -5,38 +5,41 @@ on:
     branches: [main]
 
 jobs:
+  check-paths:
+    runs-on: ubuntu-latest
+    outputs:
+      needed: ${{ steps.detect.outputs.needed }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - id: detect
+        run: |
+          if git diff --name-only origin/main...HEAD | grep -qE '^(packages/prisma-next/|\.changeset/)'; then
+            echo "needed=true" >> $GITHUB_OUTPUT
+          else
+            echo "needed=false" >> $GITHUB_OUTPUT
+          fi
+
   changeset:
     name: Changeset required
-    if: "!startsWith(github.head_ref, 'changeset-release/')"
+    needs: check-paths
+    if: needs.check-paths.outputs.needed == 'true' && !startsWith(github.head_ref, 'changeset-release/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - name: Check if changeset is needed
-        id: check-paths
-        run: |
-          if git diff --name-only origin/main...HEAD | grep -qE '^(packages/prisma-next/|\.changeset/)'; then
-            echo "needed=true" >> $GITHUB_OUTPUT
-          else
-            echo "needed=false" >> $GITHUB_OUTPUT
-            echo "No prisma-next changes — skipping changeset check."
-          fi
-
       - uses: pnpm/action-setup@v6
-        if: steps.check-paths.outputs.needed == 'true'
 
       - uses: actions/setup-node@v6
-        if: steps.check-paths.outputs.needed == 'true'
         with:
           node-version: "lts/*"
           cache: "pnpm"
 
       - name: Install dependencies
-        if: steps.check-paths.outputs.needed == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Check for changeset
-        if: steps.check-paths.outputs.needed == 'true'
         run: pnpm changeset status --since=origin/main

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -15,21 +15,28 @@ jobs:
           fetch-depth: 0
 
       - name: Check if changeset is needed
+        id: check-paths
         run: |
-          if ! git diff --name-only origin/main...HEAD | grep -qE '^(packages/prisma-next/|\.changeset/)'; then
-            echo "No prisma-next changes detected, skipping changeset check."
-            exit 0
+          if git diff --name-only origin/main...HEAD | grep -qE '^(packages/prisma-next/|\.changeset/)'; then
+            echo "needed=true" >> $GITHUB_OUTPUT
+          else
+            echo "needed=false" >> $GITHUB_OUTPUT
+            echo "No prisma-next changes — skipping changeset check."
           fi
 
       - uses: pnpm/action-setup@v6
+        if: steps.check-paths.outputs.needed == 'true'
 
       - uses: actions/setup-node@v6
+        if: steps.check-paths.outputs.needed == 'true'
         with:
           node-version: "lts/*"
           cache: "pnpm"
 
       - name: Install dependencies
+        if: steps.check-paths.outputs.needed == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Check for changeset
+        if: steps.check-paths.outputs.needed == 'true'
         run: pnpm changeset status --since=origin/main

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -3,9 +3,6 @@ name: Changeset check
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "packages/prisma-next/**"
-      - ".changeset/**"
 
 jobs:
   changeset:
@@ -16,6 +13,13 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+
+      - name: Check if changeset is needed
+        run: |
+          if ! git diff --name-only origin/main...HEAD | grep -qE '^(packages/prisma-next/|\.changeset/)'; then
+            echo "No prisma-next changes detected, skipping changeset check."
+            exit 0
+          fi
 
       - uses: pnpm/action-setup@v6
 

--- a/.github/workflows/release-prisma-next.yml
+++ b/.github/workflows/release-prisma-next.yml
@@ -41,8 +41,9 @@ jobs:
       - name: Create release PR or publish
         uses: changesets/action@v1
         with:
-          publish: pnpm changeset publish --provenance
+          publish: pnpm changeset publish
           title: "chore: release prisma-next packages"
           commit: "chore: release prisma-next packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary
- `pnpm changeset publish` does not accept `--provenance` as a CLI flag (it's an `npm publish` flag)
- Moves provenance opt-in to `NPM_CONFIG_PROVENANCE: true` env var, which pnpm passes through to npm on publish

## Test plan
- Merge → release workflow fires on the workflow file path change → publishes with provenance correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package release workflow configuration to improve security measures for npm package publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->