### PR TITLE
fix: exclude non-publishable packages from changeset publish

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -21,5 +21,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": ["@prisma-idb/idb-client-generator"]
 }

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
       - id: detect
         run: |
-          if git diff --name-only origin/main...HEAD | grep -qE '^(packages/prisma-next/|\.changeset/)'; then
+          if git diff --name-only origin/main...HEAD | grep -qE '^(packages/prisma-next/|\.changeset/[^/]+\.md)'; then
             echo "needed=true" >> $GITHUB_OUTPUT
           else
             echo "needed=false" >> $GITHUB_OUTPUT

--- a/apps/usage/package.json
+++ b/apps/usage/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@prisma-idb/usage",
   "version": "0.0.1",
+  "private": true,
   "type": "module",
   "prisma": {
     "schema": "./src/prisma/schema.prisma"

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -2,6 +2,7 @@
   "name": "@prisma-idb/idb-client-generator",
   "description": "Prisma generator for a type-safe IndexedDB client with optional sync",
   "version": "0.0.0-semantically-released",
+  "private": true,
   "main": "dist/generator.js",
   "license": "MIT",
   "bin": {

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -2,7 +2,6 @@
   "name": "@prisma-idb/idb-client-generator",
   "description": "Prisma generator for a type-safe IndexedDB client with optional sync",
   "version": "0.0.0-semantically-released",
-  "private": true,
   "main": "dist/generator.js",
   "license": "MIT",
   "bin": {

--- a/tests/schema-gen/package.json
+++ b/tests/schema-gen/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@prisma-idb/schema-gen-tests",
   "version": "1.0.0",
+  "private": true,
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- `@prisma-idb/usage` and `@prisma-idb/schema-gen-tests` marked `"private": true` — they're an example app and test package, not meant for npm
- `@prisma-idb/idb-client-generator` added to changeset `ignore` list — it's published via its own release-it flow, changeset publish should leave it alone

## Test plan
- Merge → next release run should only publish `@prisma-next-idb/*` packages